### PR TITLE
feat(#16): add factory constructors to Route and remove abstract modifier

### DIFF
--- a/.website/overview/routes.md
+++ b/.website/overview/routes.md
@@ -5,7 +5,19 @@ They only exposes the endpoint and the method that the route will respond to so 
 
 ## Create a route
 
-To add routes you first need to create a class that extends the `Route` class and then add it to the controller using the `on` method.
+To add routes you can either create a class that extends the `Route` class or use the following methods to create one. 
+
+- `Route.get`
+- `Route.post`
+- `Route.put`
+- `Route.delete`
+- `Route.patch`
+
+All this methods has a required parameter `path` that is the path of the route and the method signature corresponds to the method that the route will respond to.
+
+This change was made to reduce the boilerplate code needed to create a route and to make the code more readable.
+
+Then you can add it to the controller using the `on` method.
 
 ::: code-group
 
@@ -16,6 +28,11 @@ import 'my_routes.dart';
 class MyController extends Controller {
   MyController({super.path = '/'}) {
     on(GetRoute(path: '/'), (context) {
+      return Response.text(
+        data: 'Hello World!',
+      );
+    });
+    on(Route.get(path: '/'), (context) { // This is the same as the previous route
       return Response.text(
         data: 'Hello World!',
       );

--- a/packages/serinus/bin/serinus.dart
+++ b/packages/serinus/bin/serinus.dart
@@ -118,6 +118,9 @@ class HomeController extends Controller {
       return Response.text(
           '${context.request.getData('test')} ${context.pathParameters}');
     });
+    on(Route.get('/test'), (context) async {
+      return Response.text('Hello world from test');
+    });
   }
 }
 

--- a/packages/serinus/lib/src/core/route.dart
+++ b/packages/serinus/lib/src/core/route.dart
@@ -3,7 +3,7 @@ import 'guard.dart';
 import 'pipe.dart';
 
 /// The [Route] class is used to define the routes of the application.
-abstract class Route {
+class Route {
   /// The path of the route.
   final String path;
 
@@ -28,4 +28,30 @@ abstract class Route {
     required this.method,
     this.queryParameters = const {},
   });
+
+  /// The [Route.get] factory constructor is used to create a new instance of the [Route] class with the GET method.
+  factory Route.get(String path) {
+    return Route(path: path, method: HttpMethod.get);
+  }
+
+  /// The [Route.post] factory constructor is used to create a new instance of the [Route] class with the POST method.
+  factory Route.post(String path) {
+    return Route(path: path, method: HttpMethod.post);
+  }
+
+  /// The [Route.put] factory constructor is used to create a new instance of the [Route] class with the PUT method.
+  factory Route.put(String path) {
+    return Route(path: path, method: HttpMethod.put);
+  }
+
+  /// The [Route.delete] factory constructor is used to create a new instance of the [Route] class with the DELETE method.
+  factory Route.delete(String path) {
+    return Route(path: path, method: HttpMethod.delete);
+  }
+
+  /// The [Route.patch] factory constructor is used to create a new instance of the [Route] class with the PATCH method.
+  factory Route.patch(String path) {
+    return Route(path: path, method: HttpMethod.patch);
+  }
+
 }

--- a/packages/serinus/test/commons/body_size_limit_test.dart
+++ b/packages/serinus/test/commons/body_size_limit_test.dart
@@ -138,7 +138,6 @@ void main() {
       request.add(utf8.encode(jsonEncode({'id': 'json-obj'})));
       final response = await request.close();
       expect(response, isA<HttpClientResponse>());
-      print(await utf8.decoder.bind(response).join());
       expect(response.statusCode, 413);
     });
   });

--- a/packages/serinus/test/core/route_test.dart
+++ b/packages/serinus/test/core/route_test.dart
@@ -1,0 +1,40 @@
+import 'package:serinus/serinus.dart';
+import 'package:test/test.dart';
+
+void main() {
+
+  group('$Route', () {
+      
+      test('when a route is created, then it should have the correct path and method', () {
+        final route = Route(path: '/test', method: HttpMethod.get);
+        expect(route.path, equals('/test'));
+        expect(route.method, equals(HttpMethod.get));
+      });
+  
+      test('when a route is created with the GET factory constructor, then it should have the correct method', () {
+        final route = Route.get('/test');
+        expect(route.method, equals(HttpMethod.get));
+      });
+  
+      test('when a route is created with the POST factory constructor, then it should have the correct method', () {
+        final route = Route.post('/test');
+        expect(route.method, equals(HttpMethod.post));
+      });
+  
+      test('when a route is created with the PUT factory constructor, then it should have the correct method', () {
+        final route = Route.put('/test');
+        expect(route.method, equals(HttpMethod.put));
+      });
+  
+      test('when a route is created with the DELETE factory constructor, then it should have the correct method', () {
+        final route = Route.delete('/test');
+        expect(route.method, equals(HttpMethod.delete));
+      });
+  
+      test('when a route is created with the PATCH factory constructor, then it should have the correct method', () {
+        final route = Route.patch('/test');
+        expect(route.method, equals(HttpMethod.patch));
+      });
+  });
+
+}


### PR DESCRIPTION
# Description

To reduce the classes needed to develop a Serinus Application, the Route class has been made a concrete one and the factory constructors required have been implemented.

Fixes #16 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

