### PR TITLE
fix(#41): add content length when sending a rendered view

### DIFF
--- a/packages/serinus/bin/serinus.dart
+++ b/packages/serinus/bin/serinus.dart
@@ -5,9 +5,7 @@ import 'package:serinus/serinus.dart';
 import 'package:shelf/shelf.dart' as shelf;
 
 class TestObj with JsonObject {
-
   final String name;
-
 
   TestObj(this.name);
 
@@ -17,8 +15,6 @@ class TestObj with JsonObject {
       'name': name,
     };
   }
-
-
 }
 
 class TestMiddleware extends Middleware {
@@ -116,9 +112,12 @@ class PostRoute extends Route {
 
 class HomeController extends Controller {
   HomeController({super.path = '/'}) {
-    on(GetRoute(path: '/'), (context) async {
-      return Response.json([TestObj('Hello'), TestObj('World')]);
-    },);
+    on(
+      GetRoute(path: '/'),
+      (context) async {
+        return Response.json([TestObj('Hello'), TestObj('World')]);
+      },
+    );
     on(PostRoute(path: '/*'), (context) async {
       return Response.text(
           '${context.request.getData('test')} ${context.params}');

--- a/packages/serinus/lib/src/core/controller.dart
+++ b/packages/serinus/lib/src/core/controller.dart
@@ -51,7 +51,8 @@ abstract class Controller {
     final routeExists = _routes.values.any(
         (r) => r.route.path == route.path && r.route.method == route.method);
     if (routeExists) {
-      throw StateError('A route of type $R already exists in this controller');
+      throw StateError(
+          'A route with the same path and method already exists. [${route.path}] [${route.method}]');
     }
 
     _routes[UuidV4().generate()] =

--- a/packages/serinus/lib/src/core/middleware.dart
+++ b/packages/serinus/lib/src/core/middleware.dart
@@ -30,7 +30,8 @@ abstract class Middleware {
   /// It is used to create a middleware from a shelf middleware giving interoperability between Serinus and Shelf.
   factory Middleware.shelf(Function handler,
       {List<String> routes = const ['*'], bool ignoreResponse = true}) {
-    return _ShelfMiddleware(handler, routes: routes, ignoreResponse: ignoreResponse);
+    return _ShelfMiddleware(handler,
+        routes: routes, ignoreResponse: ignoreResponse);
   }
 }
 
@@ -39,7 +40,8 @@ class _ShelfMiddleware extends Middleware {
 
   final bool ignoreResponse;
 
-  _ShelfMiddleware(this._handler, {super.routes = const ['*'], this.ignoreResponse = true});
+  _ShelfMiddleware(this._handler,
+      {super.routes = const ['*'], this.ignoreResponse = true});
 
   /// Most of the code has been taken from
   /// https://github.com/codekeyz/pharaoh/tree/main/packages/pharaoh/lib/src/shelf_interop

--- a/packages/serinus/lib/src/http/internal_response.dart
+++ b/packages/serinus/lib/src/http/internal_response.dart
@@ -121,16 +121,6 @@ class InternalResponse {
       _events.add(ResponseEvent.error);
       throw StateError('ViewEngine is required to render views');
     }
-    if (result.data is View || result.data is ViewString) {
-      contentType(ContentType.html);
-      final rendered = await (result.data is View
-          ? viewEngine!.render(result.data)
-          : viewEngine!.renderString(result.data));
-      for (final hook in hooks) {
-        await hook.onResponse(result);
-      }
-      return send(utf8.encode(rendered));
-    }
     headers(result.headers);
     if (versioning != null && versioning.type == VersioningType.header) {
       _original.headers.add(versioning.header!, versioning.version.toString());
@@ -139,6 +129,19 @@ class InternalResponse {
     _original.headers.set(HttpHeaders.transferEncodingHeader, 'chunked');
     if (result.contentLength != null) {
       _original.headers.contentLength = result.contentLength!;
+    }
+    if (result.data is View || result.data is ViewString) {
+      contentType(ContentType.html);
+      final rendered = await (result.data is View
+          ? viewEngine!.render(result.data)
+          : viewEngine!.renderString(result.data));
+      for (final hook in hooks) {
+        await hook.onResponse(result);
+      }
+      headers({
+        HttpHeaders.contentLengthHeader: utf8.encode(rendered).length.toString()
+      });
+      return send(utf8.encode(rendered));
     }
     final data = result.data;
     final coding = _original.headers['transfer-encoding']?.join(';');

--- a/packages/serinus/lib/src/http/response.dart
+++ b/packages/serinus/lib/src/http/response.dart
@@ -71,12 +71,13 @@ class Response {
   /// This method is used to parse a JSON response.
   static dynamic _parseJsonableResponse(dynamic data) {
     dynamic responseData;
-    if(data is Map<String, dynamic>) {
+    if (data is Map<String, dynamic>) {
       responseData = data.map((key, value) {
-        if(value is JsonObject) {
+        if (value is JsonObject) {
           return MapEntry(key, _parseJsonableResponse(value.toJson()));
         } else if (value is List<JsonObject>) {
-          return MapEntry(key, value.map((e) => _parseJsonableResponse(e.toJson())).toList());
+          return MapEntry(key,
+              value.map((e) => _parseJsonableResponse(e.toJson())).toList());
         }
         return MapEntry(key, value);
       });
@@ -84,11 +85,11 @@ class Response {
       responseData = data.map((e) => _parseJsonableResponse(e)).toList();
     } else if (data is JsonObject) {
       responseData = _parseJsonableResponse(data.toJson());
-    } else if(data is List<JsonObject>) {
-      responseData = data.map((e) => _parseJsonableResponse(e.toJson())).toList();
+    } else if (data is List<JsonObject>) {
+      responseData =
+          data.map((e) => _parseJsonableResponse(e.toJson())).toList();
     } else {
-      throw FormatException(
-          'The data must be a json parsable type');
+      throw FormatException('The data must be a json parsable type');
     }
     return responseData;
   }

--- a/packages/serinus/test/core/middlewares_test.dart
+++ b/packages/serinus/test/core/middlewares_test.dart
@@ -27,7 +27,8 @@ class TestController extends Controller {
 }
 
 final shelfAltMiddleware = Middleware.shelf(
-    (req) => shelf.Response.ok('Hello world from shelf', headers: req.headers), ignoreResponse: false);
+    (req) => shelf.Response.ok('Hello world from shelf', headers: req.headers),
+    ignoreResponse: false);
 
 final shelfMiddleware = Middleware.shelf((shelf.Handler innerHandler) {
   return (shelf.Request request) {

--- a/packages/serinus/test/http/responses_test.dart
+++ b/packages/serinus/test/http/responses_test.dart
@@ -206,30 +206,22 @@ void main() async {
     test(
       '''when a mixed json response is passed, then the data should be parsed correctly''',
       () async {
-        final res = Response.json(
-          [
-            {
-              'id': 1,
-              'name': 'John Doe',
-              'email': '',
-              'obj': TestJsonObject()
-            },
-            TestObj('Jane Doe')
-          ]
-        );
-        expect(res.data, jsonEncode([
-          {
-            'id': 1,
-            'name': 'John Doe',
-            'email': '',
-            'obj': {'id': 'json-obj'}
-          },
-          {
-            'name': 'Jane Doe'
-          }
-        ]));
+        final res = Response.json([
+          {'id': 1, 'name': 'John Doe', 'email': '', 'obj': TestJsonObject()},
+          TestObj('Jane Doe')
+        ]);
+        expect(
+            res.data,
+            jsonEncode([
+              {
+                'id': 1,
+                'name': 'John Doe',
+                'email': '',
+                'obj': {'id': 'json-obj'}
+              },
+              {'name': 'Jane Doe'}
+            ]));
       },
     );
-
   });
 }


### PR DESCRIPTION
# Description

Fix the `Response.render` and `Response.renderString` methods. Add Content-Length when using these two functions.

Fixes #41 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

