### PR TITLE
feat: simplify setGlobalPrefix method in Serinus (closes #73)

### DIFF
--- a/.website/techniques/global_prefix.md
+++ b/.website/techniques/global_prefix.md
@@ -4,7 +4,7 @@ The global prefix is a prefix that is added to all the routes in the application
 
 ## Adding a Global Prefix
 
-To add a global prefix to your application, you can use the `setGlobalPrefix` method of the `SerinusApplication`. This method takes the `GlobalPrefix` class as an argument.
+To add a global prefix to your application, you can use the `globalPrefix` setter of the `SerinusApplication`. This method takes a `String` as an argument.
 
 Here is an example of how you can add a global prefix to your application:
 
@@ -14,7 +14,20 @@ import 'package:serinus/serinus.dart';
 void main() async {
   final app = await serinus.createApplication(
       entrypoint: AppModule());
-  app.setGlobalPrefix('/api');
+  app.globalPrefix = '/api';
   await app.serve();
 }
 ```
+
+::: warning
+If you pass as global prefix the string `/`, the change will be ignored.
+:::
+
+In the following table there are some examples of how the string passed will be normalized:
+
+| Input | Normalized |
+|-------|------------|
+| `/api` | `/api` |
+| `api` | `/api` |
+| `api/` | `/api` |
+| `/api/` | `/api` |

--- a/.website/techniques/global_prefix.md
+++ b/.website/techniques/global_prefix.md
@@ -14,7 +14,7 @@ import 'package:serinus/serinus.dart';
 void main() async {
   final app = await serinus.createApplication(
       entrypoint: AppModule());
-  app.setGlobalPrefix(GlobalPrefix(prefix: '/api'));
+  app.setGlobalPrefix('/api');
   await app.serve();
 }
 ```

--- a/packages/serinus/bin/serinus.dart
+++ b/packages/serinus/bin/serinus.dart
@@ -117,9 +117,12 @@ class PostRoute extends Route {
 
 class HomeController extends Controller {
   HomeController({super.path = '/'}) {
-    on(GetRoute(path: '/'), (context) async {
-      return 'Hello world';
-    },);
+    on(
+      GetRoute(path: '/'),
+      (context) async {
+        return 'Hello world';
+      },
+    );
     on(PostRoute(path: '/*'), (context) async {
       return '${context.request.getData('test')} ${context.params}';
     },

--- a/packages/serinus/lib/src/adapters/http_adapter.dart
+++ b/packages/serinus/lib/src/adapters/http_adapter.dart
@@ -4,11 +4,11 @@ import '../http/internal_request.dart';
 import 'server_adapter.dart';
 
 /// The [HttpAdapter] class is used to create an HTTP server adapter.
-/// 
+///
 /// It extends the [Adapter] class and allows the developer to define the host, port, and powered by header.
-/// 
+///
 /// The class must be extended and the [init], [close], and [listen] methods must be implemented.
-/// 
+///
 /// Properties:
 /// - [host]: The host of the server.
 /// - [port]: The port of the server.

--- a/packages/serinus/lib/src/containers/module_container.dart
+++ b/packages/serinus/lib/src/containers/module_container.dart
@@ -63,14 +63,16 @@ final class ModulesContainer {
   Future<void> registerModule(Module module, Type entrypoint,
       [ModuleInjectables? moduleInjectables]) async {
     final token = moduleToken(module);
-    final initializedModule = _modules[token] = await module.registerAsync(config);
+    final initializedModule =
+        _modules[token] = await module.registerAsync(config);
     if (initializedModule.runtimeType == entrypoint &&
         initializedModule.exports.isNotEmpty) {
       throw InitializationError('The entrypoint module cannot have exports');
     }
     _providers[token] = [];
     if (_moduleInjectables.containsKey(token)) {
-      _moduleInjectables[token] = moduleInjectables!.concatTo(_moduleInjectables[token]);
+      _moduleInjectables[token] =
+          moduleInjectables!.concatTo(_moduleInjectables[token]);
     } else {
       final newInjectables = ModuleInjectables(
         middlewares: {...module.middlewares},

--- a/packages/serinus/lib/src/core/application.dart
+++ b/packages/serinus/lib/src/core/application.dart
@@ -99,6 +99,8 @@ class SerinusApplication extends Application {
     required super.config,
     super.level,
     super.loggerService,
+    super.router,
+    super.modulesContainer,
   });
 
   @override
@@ -117,7 +119,7 @@ class SerinusApplication extends Application {
   }
 
   /// The [setGlobalPrefix] method is used to set the global prefix of the application.
-  void setGlobalPrefix(String prefix) {
+  set globalPrefix(String prefix) {
     if (prefix == '/') {
       return;
     }

--- a/packages/serinus/lib/src/core/application.dart
+++ b/packages/serinus/lib/src/core/application.dart
@@ -117,8 +117,17 @@ class SerinusApplication extends Application {
   }
 
   /// The [setGlobalPrefix] method is used to set the global prefix of the application.
-  void setGlobalPrefix(GlobalPrefix prefix) {
-    config.globalPrefix = prefix;
+  void setGlobalPrefix(String prefix) {
+    if(prefix == '/') {
+      return;
+    }
+    if(!prefix.startsWith('/')) {
+      prefix = '/$prefix';
+    }
+    if(prefix.endsWith('/')) {
+      prefix = prefix.substring(0, prefix.length - 1);
+    }
+    config.globalPrefix = GlobalPrefix(prefix: prefix);
   }
 
   @override

--- a/packages/serinus/lib/src/core/application.dart
+++ b/packages/serinus/lib/src/core/application.dart
@@ -118,13 +118,13 @@ class SerinusApplication extends Application {
 
   /// The [setGlobalPrefix] method is used to set the global prefix of the application.
   void setGlobalPrefix(String prefix) {
-    if(prefix == '/') {
+    if (prefix == '/') {
       return;
     }
-    if(!prefix.startsWith('/')) {
+    if (!prefix.startsWith('/')) {
       prefix = '/$prefix';
     }
-    if(prefix.endsWith('/')) {
+    if (prefix.endsWith('/')) {
       prefix = prefix.substring(0, prefix.length - 1);
     }
     config.globalPrefix = GlobalPrefix(prefix: prefix);

--- a/packages/serinus/lib/src/extensions/iterable_extansions.dart
+++ b/packages/serinus/lib/src/extensions/iterable_extansions.dart
@@ -19,7 +19,7 @@ extension AddIfAbsent<T> on Iterable<T> {
   Iterable<T> addAllIfAbsent(Iterable<T> elements) {
     final elementsType = map((e) => e.runtimeType);
     final currentElements = [...this];
-    for(final element in elements) {
+    for (final element in elements) {
       if (!elementsType.contains(element.runtimeType)) {
         currentElements.add(element);
       }

--- a/packages/serinus/lib/src/handlers/handler.dart
+++ b/packages/serinus/lib/src/handlers/handler.dart
@@ -52,10 +52,7 @@ abstract class Handler {
   RequestContext buildRequestContext(Iterable<Provider> providers,
       Request request, InternalResponse response) {
     return RequestContext(
-      {
-        for (final provider in providers)
-          provider.runtimeType: provider
-      },
+      {for (final provider in providers) provider.runtimeType: provider},
       request,
       StreamableResponse(response),
     );

--- a/packages/serinus/lib/src/handlers/request_handler.dart
+++ b/packages/serinus/lib/src/handlers/request_handler.dart
@@ -50,7 +50,7 @@ class RequestHandler extends Handler {
             : request.path,
         request.method.toHttpMethod());
     final routeData = routeLookup.route;
-    if(routeLookup.params.isNotEmpty) {
+    if (routeLookup.params.isNotEmpty) {
       wrappedRequest.params = routeLookup.params;
     }
     if (routeData == null) {

--- a/packages/serinus/test/injector/explorer_test.dart
+++ b/packages/serinus/test/injector/explorer_test.dart
@@ -100,6 +100,69 @@ void main() {
     });
 
     test(
+        'when the $GlobalPrefix is set to a simple slash, then the global prefix will be ignored',
+        () async {
+      final config = ApplicationConfig(
+          host: 'localhost',
+          port: 3000,
+          poweredByHeader: 'Powered by Serinus',
+          securityContext: null,
+          serverAdapter: SerinusHttpAdapter(
+            host: 'localhost',
+            port: 3000,
+            poweredByHeader: 'Powered by Serinus',
+          ));
+      final app = SerinusApplication(
+          entrypoint: SimpleMockModule(controllers: [MockController()]),
+          config: config,
+          level: LogLevel.none);
+      app.globalPrefix = '/';
+      expect(app.config.globalPrefix, isNull);
+    });
+
+    test(
+        'when the $GlobalPrefix is set to a prefix without a leading slash, then the global prefix will be normalized',
+        () async {
+      final config = ApplicationConfig(
+          host: 'localhost',
+          port: 3000,
+          poweredByHeader: 'Powered by Serinus',
+          securityContext: null,
+          serverAdapter: SerinusHttpAdapter(
+            host: 'localhost',
+            port: 3000,
+            poweredByHeader: 'Powered by Serinus',
+          ));
+      final app = SerinusApplication(
+          entrypoint: SimpleMockModule(controllers: [MockController()]),
+          config: config,
+          level: LogLevel.none);
+      app.globalPrefix = 'api';
+      expect(app.config.globalPrefix!.prefix, '/api');
+    });
+
+    test(
+        'when the $GlobalPrefix is set to a prefix with a trailing slash, then the global prefix will be normalized',
+        () async {
+      final config = ApplicationConfig(
+          host: 'localhost',
+          port: 3000,
+          poweredByHeader: 'Powered by Serinus',
+          securityContext: null,
+          serverAdapter: SerinusHttpAdapter(
+            host: 'localhost',
+            port: 3000,
+            poweredByHeader: 'Powered by Serinus',
+          ));
+      final app = SerinusApplication(
+          entrypoint: SimpleMockModule(controllers: [MockController()]),
+          config: config,
+          level: LogLevel.none);
+      app.globalPrefix = '/api/';
+      expect(app.config.globalPrefix!.prefix, '/api');
+    });
+
+    test(
         'when the $GlobalPrefix and $VersioningOptions are set, then the route path will be prefixed with the global prefix and the version',
         () async {
       final config = ApplicationConfig(


### PR DESCRIPTION
# Description

The utility class will be used only for internal reference, the users can now use a simple string to manage the global prefix.

Also the method `setGlobalPrefix` has been changed with an actual setter called `globalPrefix`

Fixes #73 

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

