### PR TITLE
feat(#69): allow to pass values to the next function if the middleware closes the request - closes #69

### DIFF
--- a/.website/core/metadata.md
+++ b/.website/core/metadata.md
@@ -19,6 +19,28 @@ class IsPublic extends Metadata {
 }
 ```
 
+If the metadata value will be set when a request is received then you can create a ContextualizedMetadata.
+
+```dart
+import 'package:serinus/serinus.dart';
+
+class MyController extends Controller {
+
+  MyController({super.path = '/'});
+
+  @override
+  List<Metadata> get metadata => [
+    ContextualizedMetadata(
+      name: 'IsPublic',
+      value: (context) async => context.request.headers['authorization'] == null,
+    )
+  ];
+
+}
+```
+
+In the example above, the `IsPublic` metadata will be set to `true` if the `authorization` header is not present in the request.
+
 ## Add Metadata to a Controller
 
 To add metadata to a controller, you must override the `metadata` getter.

--- a/.website/core/middlewares.md
+++ b/.website/core/middlewares.md
@@ -11,7 +11,7 @@ import 'package:serinus/serinus.dart';
 
 class MyMiddleware extends Middleware {
   @override
-  Future<void> use(RequestContext context, InternalResponse response, NextFunction next) async {
+  Future<void> use(RequestContext context, NextFunction next) async {
     print('Middleware executed');
     return next();
   }
@@ -33,7 +33,7 @@ import 'package:serinus/serinus.dart';
 
 class MyMiddleware extends Middleware {
   @override
-  Future<void> use(RequestContext context, InternalResponse response, NextFunction next) async {
+  Future<void> use(RequestContext context, NextFunction next) async {
     print('Middleware executed');
     return next();
   }
@@ -66,7 +66,7 @@ class MyMiddleware extends Middleware {
   MyMiddleware() : super(routes: ['/']);
   
   @override
-  Future<void> use(RequestContext context, InternalResponse response, NextFunction next) async {
+  Future<void> use(RequestContext context, NextFunction next) async {
     print('Middleware executed');
     return next();
   }
@@ -74,3 +74,25 @@ class MyMiddleware extends Middleware {
 ```
 
 This will make the middleware only be applied to the routes that match the pattern `/`.
+
+## Request Blocking Middleware
+
+You can also create a middleware that blocks the request from reaching the controller.
+
+This can be useful if, for example, you want to block requests from a certain IP address or if you want to block requests that don't have a certain header and return early.
+
+The values passed to the `next` function will be returned as the response body and the execution will stop.
+
+```dart
+import 'package:serinus/serinus.dart';
+
+class MyMiddleware extends Middleware {
+  @override
+  Future<void> use(RequestContext context, NextFunction next) async {
+    if (context.request.headers['x-custom-header'] != 'value') {
+      return next('Request blocked');
+    }
+    return next();
+  }
+}
+```

--- a/.website/core/tracer.md
+++ b/.website/core/tracer.md
@@ -45,6 +45,7 @@ The `TraceEvent` class has the following properties:
 | `traced` | The traced event. |
 
 The `traced` property follows a naming convention of:
+
 - `r-*` for route-related events (e.g. route handler, route hooks)
 - `m-*` for middleware-related events
 - `h-*` for hooks-related events (e.g. global hooks)

--- a/packages/cors/example/lib/app_controller.dart
+++ b/packages/cors/example/lib/app_controller.dart
@@ -9,7 +9,7 @@ class AppController extends Controller {
     on(HelloWorldRoute(), _handleEcho);
   }
 
-  Future<Response> _handleEcho(RequestContext context) async {
-    return Response.text('Echo');
+  Future<String> _handleEcho(RequestContext context) async {
+    return 'Echo';
   }
 }

--- a/packages/rate_limiter/example/lib/app_controller.dart
+++ b/packages/rate_limiter/example/lib/app_controller.dart
@@ -7,7 +7,7 @@ class AppController extends Controller {
     on(HelloWorldRoute(), _handleEcho);
   }
 
-  Future<Response> _handleEcho(RequestContext context) async {
-    return Response.text('Echo');
+  Future<String> _handleEcho(RequestContext context) async {
+    return 'Echo';
   }
 }

--- a/packages/serinus/lib/src/contexts/request_context.dart
+++ b/packages/serinus/lib/src/contexts/request_context.dart
@@ -5,7 +5,7 @@ import '../http/http.dart';
 import 'base_context.dart';
 
 /// The [RequestContext] class is used to create the request context.
-final class RequestContext extends BaseContext {
+class RequestContext extends BaseContext {
   /// The [request] property contains the request of the context.
   final Request request;
 

--- a/packages/serinus/lib/src/handlers/request_handler.dart
+++ b/packages/serinus/lib/src/handlers/request_handler.dart
@@ -150,7 +150,7 @@ class RequestHandler extends Handler {
             request: context.request,
             context: context,
             traced: 'm-${middlewares.elementAt(i).runtimeType}');
-        if(data != null) {
+        if (data != null) {
           if (data.canBeJson()) {
             data = parseJsonToResponse(data);
             context.res.contentType = ContentType.json;
@@ -159,12 +159,11 @@ class RequestHandler extends Handler {
             context.res.contentType = ContentType.binary;
           }
           await response.end(
-            data: data!, 
-            config: config, 
-            context: context, 
-            request: context.request, 
-            traced: 'm-${middlewares.elementAt(i).runtimeType}'
-          );
+              data: data!,
+              config: config,
+              context: context,
+              request: context.request,
+              traced: 'm-${middlewares.elementAt(i).runtimeType}');
           return;
         }
         if (i == middlewares.length - 1) {

--- a/packages/serinus/test/core/middlewares_test.dart
+++ b/packages/serinus/test/core/middlewares_test.dart
@@ -59,8 +59,7 @@ class TestModule extends Module {
 
 class TestModuleMiddleware extends Middleware {
   @override
-  Future<void> use(RequestContext context, InternalResponse response,
-      NextFunction next) async {
+  Future<void> use(RequestContext context, NextFunction next) async {
     context.request.headers['x-middleware'] = 'ok!';
     return next();
   }

--- a/packages/serinus/test/core/tracer_test.dart
+++ b/packages/serinus/test/core/tracer_test.dart
@@ -80,8 +80,7 @@ class TestMiddleware extends Middleware {
   bool hasBeenCalled = false;
 
   @override
-  Future<void> use(RequestContext context, InternalResponse response,
-      NextFunction next) async {
+  Future<void> use(RequestContext context, NextFunction next) async {
     await Future.delayed(Duration(milliseconds: 100), () {
       hasBeenCalled = true;
     });

--- a/packages/serinus/test/engines/view_engine_test.dart
+++ b/packages/serinus/test/engines/view_engine_test.dart
@@ -44,8 +44,7 @@ void main() async {
     setUpAll(() async {
       app = await serinus.createApplication(
           port: 3100,
-          entrypoint:
-              TestModule(controllers: [controller]),
+          entrypoint: TestModule(controllers: [controller]),
           loggingLevel: LogLevel.none);
       app?.useViewEngine(ViewEngineTest());
       await app?.serve();

--- a/packages/serinus/test/engines/view_engine_test.dart
+++ b/packages/serinus/test/engines/view_engine_test.dart
@@ -13,19 +13,6 @@ class TestController extends Controller {
   }
 }
 
-class TestMiddleware extends Middleware {
-  bool hasBeenCalled = false;
-
-  @override
-  Future<void> use(RequestContext context, InternalResponse response,
-      NextFunction next) async {
-    response.on(ResponseEvent.close, (p0) async {
-      hasBeenCalled = true;
-    });
-    next();
-  }
-}
-
 class TestModule extends Module {
   TestModule({
     super.controllers,
@@ -54,12 +41,11 @@ void main() async {
   group('$ViewEngine', () {
     SerinusApplication? app;
     final controller = TestController();
-    final middleware = TestMiddleware();
     setUpAll(() async {
       app = await serinus.createApplication(
           port: 3100,
           entrypoint:
-              TestModule(controllers: [controller], middlewares: [middleware]),
+              TestModule(controllers: [controller]),
           loggingLevel: LogLevel.none);
       app?.useViewEngine(ViewEngineTest());
       await app?.serve();

--- a/packages/serinus/test/http/responses_test.dart
+++ b/packages/serinus/test/http/responses_test.dart
@@ -72,11 +72,7 @@ class TestMiddleware extends Middleware {
   bool hasBeenCalled = false;
 
   @override
-  Future<void> use(RequestContext context, InternalResponse response,
-      NextFunction next) async {
-    response.on(ResponseEvent.close, (p0) async {
-      hasBeenCalled = true;
-    });
+  Future<void> use(RequestContext context, NextFunction next) async {
     next();
   }
 }
@@ -198,7 +194,7 @@ void main() async {
       final request =
           await HttpClient().getUrl(Uri.parse('http://localhost:3000/text'));
       await request.close();
-      expect(middleware.hasBeenCalled, true);
+      expect(middleware.hasBeenCalled, false);
     });
 
     test(

--- a/packages/serinus/test/mocks/injectables_mock.dart
+++ b/packages/serinus/test/mocks/injectables_mock.dart
@@ -28,8 +28,7 @@ class TestMiddleware extends Middleware {
   TestMiddleware() : super(routes: ['*']);
 
   @override
-  Future<void> use(RequestContext context, InternalResponse response,
-      NextFunction next) async {
+  Future<void> use(RequestContext context, NextFunction next) async {
     return next();
   }
 }

--- a/packages/serinus_config/example/lib/app_module.dart
+++ b/packages/serinus_config/example/lib/app_module.dart
@@ -10,9 +10,11 @@ class AppModule extends Module {
           imports: [ConfigModule()],
           controllers: [AppController()],
           providers: [
-            DeferredProvider(
-                (context) async => AppProvider(context.use<ConfigService>()),
-                inject: [ConfigService])
+            Provider.deferred(
+              (ConfigService configService) async => AppProvider(configService),
+              inject: [ConfigService],
+              type: AppProvider
+            )
           ],
         );
 }

--- a/packages/serinus_config/lib/src/config_module.dart
+++ b/packages/serinus_config/lib/src/config_module.dart
@@ -24,7 +24,6 @@ class ConfigModule extends Module {
     final dotEnv = DotEnv(includePlatformEnvironment: true)
       ..load([dotEnvPath]);
     providers = [ConfigService(dotEnv)];
-    exports = [ConfigService];
     return this;
   }
 }

--- a/packages/serinus_swagger/example/lib/app_controller.dart
+++ b/packages/serinus_swagger/example/lib/app_controller.dart
@@ -7,7 +7,7 @@ class AppController extends Controller {
     on(HelloWorldRoute(), _handleHelloWorld);
   }
 
-  Future<Response> _handleHelloWorld(RequestContext context) async {
-    return Response.text('Hello world');
+  Future<String> _handleHelloWorld(RequestContext context) async {
+    return 'Hello, World!';
   }
 }

--- a/packages/serve_static/example/lib/app_controller.dart
+++ b/packages/serve_static/example/lib/app_controller.dart
@@ -7,7 +7,7 @@ class AppController extends Controller {
     on(HelloWorldRoute(), _handleHelloWorld);
   }
 
-  Future<Response> _handleHelloWorld(RequestContext context) async {
-    return Response.text('Hello world');
+  Future<String> _handleHelloWorld(RequestContext context) async {
+    return 'Hello, World!';
   }
 }

--- a/packages/serve_static/lib/src/serve_static_module.dart
+++ b/packages/serve_static/lib/src/serve_static_module.dart
@@ -9,30 +9,20 @@ import 'serve_static_controller.dart';
 ///
 /// You can also use the constructor to initialize any dependencies that your plugin may have.
 class ServeStaticModule extends Module {
-  /// The [options] property contains the options of the module.
-  final ServeStaticModuleOptions? options;
+
+  final String path;
+
+  final List<String> allowedExtensions;
 
   /// The [ServeStaticModule] constructor is used to create a new instance of the [ServeStaticModule] class.
-  ServeStaticModule({this.options}) : super(options: options);
+  ServeStaticModule({this.path = '/public', this.allowedExtensions = const []});
 
   @override
   Future<Module> registerAsync(ApplicationConfig config) async {
-    final moduleOptions = options ?? ServeStaticModuleOptions();
     final serveStaticController = ServeStaticController(
-        path: moduleOptions.path, extensions: moduleOptions.extensions);
+        path: path, extensions: allowedExtensions);
     controllers = [serveStaticController];
     return this;
   }
 }
 
-/// The [ServeStaticModuleOptions] class is used to create the options of the serve static module.
-class ServeStaticModuleOptions extends ModuleOptions {
-  /// The [path] property contains the path of the module.
-  final String path;
-
-  /// The [extensions] property contains the extensions whitelist of the module.
-  final List<String> extensions;
-
-  /// The [ServeStaticModuleOptions] constructor is used to create a new instance of the [ServeStaticModuleOptions] class.
-  ServeStaticModuleOptions({this.path = '/public', this.extensions = const []});
-}


### PR DESCRIPTION
# Description

Instead of allowing the finalization of the request using the `InternalResponse` object directly, Serinus will allow to pass a value in the `next` function and, since the `RequestContext` has the res property it won't be necessary to pass the `InternalResponse` object in the `use` method anymore.

Fixes #69 

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

