### PR TITLE
fix(#89): add check to the statusCode setter in ResponseProperties - fixes #89

### DIFF
--- a/.website/foundations/request_context.md
+++ b/.website/foundations/request_context.md
@@ -19,6 +19,10 @@ The `RequestContext` class has the following properties:
 | **path** | The path of the request that triggered the handler |
 | **res** | Utility class to interact with the response headers and statusCode. |
 
+::: warning
+The statusCode value must be between 100 and 999.
+:::
+
 ## Methods
 
 The `RequestContext` class has the following methods:

--- a/packages/serinus/lib/src/contexts/request_context.dart
+++ b/packages/serinus/lib/src/contexts/request_context.dart
@@ -93,7 +93,18 @@ final class Redirect {
 /// It contains the status code, headers, and redirect properties.
 final class ResponseProperties {
   /// The [statusCode] property contains the status code of the response.
-  int statusCode = HttpStatus.ok;
+  int _statusCode = HttpStatus.ok;
+
+  /// The [statusCode] getter is used to get the status code of the response.
+  int get statusCode => _statusCode;
+
+  /// The [statusCode] setter is used to set the status code of the response.
+  set statusCode(int value) {
+    if (value < 100 || value > 999) {
+      throw ArgumentError('The status code must be between 100 and 999. $value is not a valid status code.');
+    }
+    _statusCode = value;
+  }
 
   /// The [contentType] property contains the content type of the response.
   ContentType? contentType;

--- a/packages/serinus/test/commons/response_properties_test.dart
+++ b/packages/serinus/test/commons/response_properties_test.dart
@@ -1,0 +1,22 @@
+import 'package:serinus/serinus.dart';
+import 'package:test/test.dart';
+
+void main() async {
+  group('$ResponseProperties', () {
+    test(
+      'should throw an error when the status code is not a valid status code',
+      () {
+        final ResponseProperties res = ResponseProperties();
+        expect(() => res.statusCode = 1000, throwsArgumentError);
+        expect(() => res.statusCode = 99, throwsArgumentError);
+    });
+
+    test(
+      'should set the status code when the status code is a valid status code',
+      () {
+        final ResponseProperties res = ResponseProperties();
+        res.statusCode = 200;
+        expect(res.statusCode, equals(200));
+    });
+  });
+}


### PR DESCRIPTION
# Description

Add a check to the statusCode setter in the ResponseProperties object

Fixes #89

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

