### PR TITLE
feat(#65): add prefix, add setLoggerPrefix, update documentation - closes #65

### DIFF
--- a/.website/.vitepress/config.mts
+++ b/.website/.vitepress/config.mts
@@ -89,6 +89,7 @@ export default defineConfig({
             base: '/techniques/',
             collapsed: true,
             items: [
+              { text: 'Logging', link: 'logging' },
               { text: 'Model View Controller', link: 'mvc' },
               { text: 'Versioning', link: 'versioning' },
               { text: 'Global Prefix', link: 'global_prefix' },

--- a/.website/techniques/logging.md
+++ b/.website/techniques/logging.md
@@ -1,0 +1,85 @@
+# Logger
+
+Serinus comes with a built-in text-based logger which is used during application bootstrapping and several other circumstances such as displaying caught exceptions. This functionality is provided through the `Logger` class.
+
+## Usage
+
+The logger as a stand-alone class and will use the properties defined in the `LoggerService`.
+
+```dart
+class TestProvider extends Provider with OnApplicationInit {
+
+  Logger logger = Logger('TestProviderFour');
+
+  TestProvider();
+
+  @override
+  Future<void> onApplicationInit() async {
+    logger.info('Provider initialized');
+  }
+}
+```
+
+This will print (if you have the default logger service):
+
+```shell
+[Serinus] 26252 20/09/2024 17:20:36     INFO [TestProviderFour] Provider initialized +0ms
+```
+
+## Change the logger prefix
+
+You can change the prefix of the logger by using the `setLoggerPrefix` method from your application.
+
+```dart
+void main(List<String> arguments) async {
+  SerinusApplication application = await serinus.createApplication(
+      entrypoint: AppModule(), host: InternetAddress.anyIPv4.address);
+  application.enableShutdownHooks();
+  application.setLoggerPrefix('MyApp');
+  await application.serve();
+}
+```
+
+This will print:
+
+```shell
+[MyApp] 26252 20/09/2024 17:20:36     INFO [TestProviderFour] Provider initialized +0ms
+```
+
+## Configure the logger service
+
+You can configure the logger service by using the `LoggerService` class.
+
+```dart
+void main(List<String> arguments) async {
+  SerinusApplication application = await serinus.createApplication(
+    entrypoint: AppModule(), 
+    host: InternetAddress.anyIPv4.address,
+    loggerService: LoggerService(
+      level: LogLevel.debug,
+      prefix: 'Serinus',
+      onLog: (prefix, record, deltaTime) {
+        print('{"prefix": "$prefix", "record": "${record.message}", "deltaTime": "${deltaTime}ms"}');
+      },
+    )
+  );
+  await application.serve();
+}
+```
+
+Doing this you will change the default behavior of the logger service and it will print:
+
+```shell
+{"prefix": "Serinus", "record": "Provider initialized", "deltaTime": "0ms"}
+```
+
+## Log levels
+
+The logger service has the following log levels:
+
+| Level | Description |
+|-------|-------------|
+| debug | All logs will be printed |
+| info  | All but debug logs will be printed |
+| error | Only severe logs will be printed |
+| none | No logs will be printed |

--- a/packages/serinus/lib/src/core/application.dart
+++ b/packages/serinus/lib/src/core/application.dart
@@ -19,7 +19,7 @@ import '../versioning.dart';
 import 'core.dart';
 
 /// The [Application] class is used to create an application.
-sealed class Application {
+abstract class Application {
   /// The [level] property contains the log level of the application.
   final LogLevel level;
 
@@ -39,6 +39,7 @@ sealed class Application {
   /// The [config] property contains the application configuration.
   final ApplicationConfig config;
 
+  /// The [Application] constructor is used to create a new instance of the [Application] class.
   Application({
     required this.entrypoint,
     required this.config,
@@ -49,6 +50,11 @@ sealed class Application {
   })  : router = router ?? Router(),
         loggerService = loggerService ?? LoggerService(level: level),
         modulesContainer = modulesContainer ?? ModulesContainer(config);
+
+  /// The [setLoggerPrefix] method is used to set the logger prefix of the application.
+  void setLoggerPrefix(String prefix) {
+    loggerService?.prefix = prefix;
+  }
 
   /// The [url] property contains the URL of the application.
   String get url;

--- a/packages/serinus/lib/src/enums/log_level.dart
+++ b/packages/serinus/lib/src/enums/log_level.dart
@@ -7,5 +7,8 @@ enum LogLevel {
   errors,
 
   /// All logs will be shown.
-  debug
+  debug,
+
+  /// All but debug logs will be shown.
+  info,
 }

--- a/packages/serinus/lib/src/services/logger_service.dart
+++ b/packages/serinus/lib/src/services/logger_service.dart
@@ -8,7 +8,7 @@ import 'package:logging/logging.dart' as logging;
 import '../enums/log_level.dart';
 
 /// The [LogCallback] is used to style the logs.
-typedef LogCallback = void Function(logging.LogRecord record, double deltaTime);
+typedef LogCallback = void Function(String prefix, logging.LogRecord record, int deltaTime);
 
 /// The [LoggerService] is used to bootstrap the logging in the application.
 class LoggerService {
@@ -20,23 +20,29 @@ class LoggerService {
   /// The [level] of the logger.
   LogLevel level;
 
+  /// The [prefix] of the logger.
+  String prefix;
+
   /// The [LoggerService] constructor is used to create a new instance of the [LoggerService] class.
   factory LoggerService({
     LogCallback? onLog,
     LogLevel level = LogLevel.debug,
+    String prefix = 'Serinus',
   }) {
-    return LoggerService._(onLog: onLog, level: level);
+    return LoggerService._(onLog: onLog, level: level, prefix: prefix);
   }
 
   LoggerService._({
     this.onLog,
     this.level = LogLevel.debug,
+    this.prefix = 'Serinus',
   }) {
     /// The root level of the logger.
     logging.Logger.root.level = switch (level) {
       LogLevel.debug => logging.Level.ALL,
       LogLevel.errors => logging.Level.SEVERE,
       LogLevel.none => logging.Level.OFF,
+      LogLevel.info => logging.Level('INFO', 101),
     };
 
     /// The listener for the logs.
@@ -45,13 +51,13 @@ class LoggerService {
           DateTime.now().millisecondsSinceEpoch / 1000 - _time.toDouble();
       _time = DateTime.now().millisecondsSinceEpoch ~/ 1000;
       if (onLog != null) {
-        onLog?.call(record, delta);
+        onLog?.call(prefix, record, delta.ceil());
         return;
       } else {
-        print('[Serinus] ${io.pid}\t'
+        print('[$prefix] ${io.pid}\t'
             '${DateFormat('dd/MM/yyyy HH:mm:ss').format(record.time)}'
             '\t${record.level.name} [${record.loggerName}] '
-            '${record.message} +${delta.toInt()}ms');
+            '${record.message} +${delta.ceil()}ms');
       }
     });
   }

--- a/packages/serinus/test/logger_service_test.dart
+++ b/packages/serinus/test/logger_service_test.dart
@@ -2,7 +2,8 @@ import 'package:mocktail/mocktail.dart';
 import 'package:serinus/serinus.dart';
 import 'package:test/test.dart';
 
-class _MockApplication extends Mock implements Application {}
+class AppModule extends Mock implements Module {}
+class _AdapterMock extends Mock implements Adapter {}
 
 void main() {
 
@@ -56,9 +57,17 @@ void main() {
         loggerService.prefix = 'Custom';
         expect(loggerService.prefix, 'Custom');
 
-        _MockApplication app = _MockApplication();
-        app.setLoggerPrefix('Custom');
-        verify(() => app.setLoggerPrefix('Custom')).called(1);
+        SerinusApplication app = SerinusApplication(
+          entrypoint: AppModule(),
+          config: ApplicationConfig(
+            port: 3000,
+            host: 'localhost',
+            poweredByHeader: 'Serinus',
+            serverAdapter: _AdapterMock(),
+          ),
+        );
+        app.setLoggerPrefix('Custom App');
+        expect(app.loggerService!.prefix, 'Custom App');
       },
     );
 

--- a/packages/serinus/test/logger_service_test.dart
+++ b/packages/serinus/test/logger_service_test.dart
@@ -1,0 +1,67 @@
+import 'package:mocktail/mocktail.dart';
+import 'package:serinus/serinus.dart';
+import 'package:test/test.dart';
+
+class _MockApplication extends Mock implements Application {}
+
+void main() {
+
+  group('$LoggerService', () {
+
+    test(
+      'should create a new instance of the LoggerService class',
+      () {
+        final loggerService = LoggerService();
+        expect(loggerService, isA<LoggerService>());
+      },
+    );
+
+    test(
+      'should create a new instance of the LoggerService class with a custom prefix',
+      () {
+        final loggerService = LoggerService(prefix: 'Custom');
+        expect(loggerService.prefix, 'Custom');
+      },
+    );
+
+    test(
+      'should create a new instance of the LoggerService class with a custom log level',
+      () {
+        final loggerService = LoggerService(level: LogLevel.errors);
+        expect(loggerService.level, LogLevel.errors);
+      },
+    );
+
+    test(
+      'should create a new instance of the LoggerService class with a custom log callback',
+      () {
+        final loggerService = LoggerService(onLog: (prefix, record, delta) {});
+        expect(loggerService.onLog, isNotNull);
+      },
+    );
+    
+    test(
+      'should allow to change the prefix of the logger',
+      () {
+        final loggerService = LoggerService();
+        loggerService.prefix = 'Custom';
+        expect(loggerService.prefix, 'Custom');
+      },
+    );
+
+    test(
+      'should allow to change the prefix of the logger',
+      () {
+        final loggerService = LoggerService();
+        loggerService.prefix = 'Custom';
+        expect(loggerService.prefix, 'Custom');
+
+        _MockApplication app = _MockApplication();
+        app.setLoggerPrefix('Custom');
+        verify(() => app.setLoggerPrefix('Custom')).called(1);
+      },
+    );
+
+  });
+
+}


### PR DESCRIPTION
# Description

Add the possibility to change the Serinus prefix in the logger to allow a more personalized experience in logging.

Fixes #65 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

