### PR TITLE
feat(#123): add force options to create command

### DIFF
--- a/packages/serinus_cli/lib/src/commands/create/create_command.dart
+++ b/packages/serinus_cli/lib/src/commands/create/create_command.dart
@@ -29,6 +29,10 @@ class CreateCommand extends Command<int> {
       ..addFlag(
         'plugin',
         help: 'Whether to create a plugin project.',
+      )
+      ..addFlag(
+        'force',
+        help: 'Force project creation even if the directory exists.',
       );
   }
 
@@ -95,11 +99,13 @@ class CreateCommand extends Command<int> {
         defaultValue: '',
       ),
     };
-
+    if(outputDirectory.existsSync() && !force) {
+      _logger?.err('Directory already exists at ${outputDirectory.absolute.path}');
+      return;
+    }
     if (!outputDirectory.existsSync()) {
       outputDirectory.createSync(recursive: true);
     }
-
     _logger?.success('Directory created at ${outputDirectory.absolute.path}');
     progress?.update('Fetching latest version of serinus package...');
     try {
@@ -144,6 +150,10 @@ class CreateCommand extends Command<int> {
         defaultValue: 'A new Serinus application',
       ),
     };
+    if(outputDirectory.existsSync() && !force) {
+      progress?.fail('Directory already exists at ${outputDirectory.absolute.path}');
+      return;
+    }
     if (!outputDirectory.existsSync()) {
       outputDirectory.createSync(recursive: true);
     }
@@ -193,6 +203,8 @@ class CreateCommand extends Command<int> {
     _validateOutputDirectoryArg(rest);
     return Directory(rest.first);
   }
+
+  bool get force => argResults['force'] as bool;
 
   bool get _isPlugin => argResults['plugin'] as bool;
 

--- a/packages/serinus_cli/pubspec.yaml
+++ b/packages/serinus_cli/pubspec.yaml
@@ -1,11 +1,11 @@
 name: serinus_cli
 description: The official CLI of the Serinus Framework. It allows you to create, build, and manage Serinus projects.
-version: 1.0.2
+version: 1.0.3
 repository: 'https://github.com/francescovallone/serinus'
 homepage: https://serinus.app
 
 environment:
-  sdk: '>=3.5.0 <4.0.0'
+  sdk: '>=3.6.0 <4.0.0'
 
 dependencies:
   analyzer: ^7.1.0


### PR DESCRIPTION
# Description

Add force option to create command to allow for the force recreation of a project.

Fixes #123

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

