### PR TITLE
feat(#152): refactor dependency injection process and add DynamicModules

### DIFF
--- a/packages/serinus/lib/src/containers/explorer.dart
+++ b/packages/serinus/lib/src/containers/explorer.dart
@@ -21,13 +21,10 @@ final class Explorer {
   /// It resolves the routes of the controllers and registers them in the router.
   void resolveRoutes() {
     final Logger logger = Logger('RoutesResolver');
-    final modules = _modulesContainer.modules;
-    Map<Controller, _ControllerSpec> controllers = {};
-    for (Module module in modules) {
-      controllers.addEntries(module.controllers.map((controller) => MapEntry(
-          controller,
-          _ControllerSpec(normalizePath(controller.path), module))));
-    }
+    Map<Controller, _ControllerSpec> controllers = {
+      for(final record in _modulesContainer.controllers)
+        record.controller:  _ControllerSpec(record.controller.path, record.module)
+    };
     for (var controller in controllers.entries) {
       if (controller.value.path.contains(RegExp(r'([\/]{2,})*([\:][\w+]+)'))) {
         throw Exception('Invalid controller path: ${controller.value.path}');

--- a/packages/serinus/lib/src/core/application.dart
+++ b/packages/serinus/lib/src/core/application.dart
@@ -8,7 +8,6 @@ import '../containers/module_container.dart';
 import '../containers/router.dart';
 import '../engines/view_engine.dart';
 import '../enums/enums.dart';
-import '../extensions/iterable_extansions.dart';
 import '../global_prefix.dart';
 import '../handlers/handler.dart';
 import '../http/http.dart';
@@ -187,14 +186,12 @@ class SerinusApplication extends Application {
   @override
   Future<void> initialize() async {
     if (!modulesContainer.isInitialized) {
-      await modulesContainer.registerModules(
-          entrypoint, entrypoint.runtimeType);
+      await modulesContainer.registerModules(entrypoint);
     }
     final explorer = Explorer(modulesContainer, router, config);
     explorer.resolveRoutes();
     await modulesContainer.finalize(entrypoint);
-    final registeredProviders =
-        modulesContainer.getAll<OnApplicationBootstrap>();
+    final registeredProviders = modulesContainer.getAll<OnApplicationBootstrap>();
     for (final provider in registeredProviders) {
       await provider.onApplicationBootstrap();
     }
@@ -203,18 +200,15 @@ class SerinusApplication extends Application {
   @override
   Future<void> shutdown() async {
     _logger.info('Shutting down server');
-    final registeredProviders =
-        modulesContainer.modules.map((e) => e.providers).flatten();
-    for (final provider in registeredProviders) {
-      if (provider is OnApplicationShutdown) {
-        await provider.onApplicationShutdown();
-      }
+    final providers = modulesContainer.getAll<OnApplicationShutdown>();
+    for (final provider in providers) {
+      await provider.onApplicationShutdown();
     }
   }
 
   @override
   Future<void> register() async {
-    await modulesContainer.registerModules(entrypoint, entrypoint.runtimeType);
+    await modulesContainer.registerModules(entrypoint);
   }
 
   /// The [use] method is used to add a hook to the application.

--- a/packages/serinus/lib/src/core/middleware.dart
+++ b/packages/serinus/lib/src/core/middleware.dart
@@ -58,6 +58,10 @@ class _ShelfMiddleware extends Middleware {
     } else {
       throw Exception('Handler must be a shelf.Middleware or a shelf.Handler');
     }
+    if(ignoreResponse) {
+      context.res.headers.addAll(shelfResponse.headers);
+      return next();
+    }
     final response = await _responseFromShelf(context, shelfResponse);
     return next(response);
   }
@@ -72,7 +76,7 @@ class _ShelfMiddleware extends Middleware {
     context.res.statusCode = response.statusCode;
     context.res.headers.addAll(headers);
     final responseBody = await response.readAsString();
-    if (responseBody.isNotEmpty && !ignoreResponse) {
+    if (responseBody.isNotEmpty) {
       return utf8.encode(responseBody);
     }
   }

--- a/packages/serinus/lib/src/core/module.dart
+++ b/packages/serinus/lib/src/core/module.dart
@@ -41,7 +41,36 @@ abstract class Module {
   });
 
   /// The [register] method is used to register the module.
-  Future<Module> registerAsync(ApplicationConfig config) async {
-    return this;
+  Future<DynamicModule> registerAsync(ApplicationConfig config) async {
+    return DynamicModule();
   }
+}
+
+/// The [DynamicModule] class is used to define a dynamic module.
+class DynamicModule {
+
+  /// The [imports] property contains the modules that are imported in the module.
+  final List<Provider> providers;
+
+  /// The [exports] property contains the exports of the module.
+  final List<Type> exports;
+
+  /// The [middlewares] property contains the middlewares of the module.
+  final List<Middleware> middlewares;
+
+  /// The [imports] property contains the modules that are imported in the module.
+  final List<Module> imports;
+
+  /// The [controllers] property contains the controllers of the module.
+  final List<Controller> controllers;
+
+  /// The [DynamicModule] constructor is used to create a new instance of the [DynamicModule] class.
+  DynamicModule({
+    this.imports = const [],
+    this.controllers = const [],
+    this.providers = const [],
+    this.exports = const [],
+    this.middlewares = const [],
+  });
+
 }

--- a/packages/serinus/lib/src/core/provider.dart
+++ b/packages/serinus/lib/src/core/provider.dart
@@ -14,6 +14,9 @@ abstract class Provider {
   factory Provider.deferred(Function init,
           {required List<Type> inject, required Type type}) =>
       DeferredProvider(init, inject: inject, type: type);
+
+  @override
+  String toString() => '$runtimeType(isGlobal: $isGlobal)';
 }
 
 /// The [DeferredProvider] class is used to define a provider that is initialized asynchronously.
@@ -31,4 +34,7 @@ class DeferredProvider extends Provider {
 
   /// The [DeferredProvider] constructor is used to create a new instance of the [DeferredProvider] class.
   DeferredProvider(this.init, {required this.inject, required this.type});
+
+  @override
+  String toString() => '$runtimeType(inject: $inject, type: $type)';
 }

--- a/packages/serinus/lib/src/core/websockets/ws_module.dart
+++ b/packages/serinus/lib/src/core/websockets/ws_module.dart
@@ -8,9 +8,9 @@ class WsModule extends Module {
   final Logger logger = Logger('WebSocket');
 
   @override
-  Future<Module> registerAsync(ApplicationConfig config) async {
+  Future<DynamicModule> registerAsync(ApplicationConfig config) async {
     config.adapters[WsAdapter] ??= WsAdapter();
     logger.info('WebSocket Module initialized.');
-    return super.registerAsync(config);
+    return DynamicModule();
   }
 }

--- a/packages/serinus/lib/src/extensions/iterable_extansions.dart
+++ b/packages/serinus/lib/src/extensions/iterable_extansions.dart
@@ -29,6 +29,7 @@ extension AddIfAbsent<T> on Iterable<T> {
     return currentElements;
   }
 
+  /// This method is used to get the missing elements from a list of elements
   Iterable<T> getMissingElements(Iterable<T> elements) {
     final elementsType = map((e) => e.runtimeType);
     final missingElements = <T>[];

--- a/packages/serinus/lib/src/extensions/iterable_extansions.dart
+++ b/packages/serinus/lib/src/extensions/iterable_extansions.dart
@@ -28,6 +28,17 @@ extension AddIfAbsent<T> on Iterable<T> {
     }
     return currentElements;
   }
+
+  Iterable<T> getMissingElements(Iterable<T> elements) {
+    final elementsType = map((e) => e.runtimeType);
+    final missingElements = <T>[];
+    for (final element in elements) {
+      if (!elementsType.contains(element.runtimeType)) {
+        missingElements.add(element);
+      }
+    }
+    return missingElements;
+  }
 }
 
 /// This extension is used to split a list into two lists based on the type

--- a/packages/serinus/lib/src/handlers/request_handler.dart
+++ b/packages/serinus/lib/src/handlers/request_handler.dart
@@ -63,14 +63,14 @@ class RequestHandler extends Handler {
               'No route found for path ${request.path} and method ${request.method}');
     }
 
-    final injectables =
-        modulesContainer.getModuleInjectablesByToken(routeData.moduleToken);
+    final scope =
+        modulesContainer.getScope(routeData.moduleToken);
     final routeSpec = routeData.spec;
     final route = routeSpec.route;
     final handler = routeSpec.handler;
     final schema = routeSpec.schema;
     final scopedProviders =
-        injectables.providers.addAllIfAbsent(modulesContainer.globalProviders);
+        scope.providers.addAllIfAbsent(modulesContainer.globalProviders);
     RequestContext context =
         buildRequestContext(scopedProviders, wrappedRequest, response);
     context.metadata = await _resolveMetadata(routeData.metadata, context);
@@ -80,7 +80,7 @@ class RequestHandler extends Handler {
       bodyValue = await executeOnParse(context, schema, route, bodyValue);
     }
 
-    final middlewares = injectables.filterMiddlewaresByRoute(
+    final middlewares = scope.filterMiddlewaresByRoute(
         routeData.path, wrappedRequest.params);
     if (middlewares.isNotEmpty) {
       await handleMiddlewares(request, context, response, middlewares, config);

--- a/packages/serinus/lib/src/handlers/websocket_handler.dart
+++ b/packages/serinus/lib/src/handlers/websocket_handler.dart
@@ -40,10 +40,8 @@ class WebSocketHandler extends Handler {
         continue;
       }
       final providerModule =
-          modulesContainer.getModuleByProvider(provider.runtimeType);
-      final injectables = modulesContainer.getModuleInjectablesByToken(
-          modulesContainer.moduleToken(providerModule));
-      final scopedProviders = List<Provider>.from(injectables.providers);
+          modulesContainer.getScopeByProvider(provider.runtimeType);
+      final scopedProviders = providerModule.providers;
       scopedProviders.remove(provider);
       final context = WebSocketContext(
           (config.adapters[WsAdapter] as WsAdapter?)!,

--- a/packages/serinus/test/containers/modules_container_test.dart
+++ b/packages/serinus/test/containers/modules_container_test.dart
@@ -19,12 +19,12 @@ void main() {
           serverAdapter: _MockAdapter(),
           poweredByHeader: 'Serinus'));
       final module = SimpleModule();
-      await container.registerModules(module, module.runtimeType);
-      expect(container.modules.length, 1);
+      await container.registerModules(module);
+      expect(container.scopes.length, 1);
     });
 
     test(
-        'registerModules should throw an $InitializationError when a module is registered multiple times',
+        'registerModules should skip registering a module if it is already registered',
         () async {
           Logger.setLogLevels({LogLevel.none});
       final container = ModulesContainer(ApplicationConfig(
@@ -33,13 +33,13 @@ void main() {
           serverAdapter: _MockAdapter(),
           poweredByHeader: 'Serinus'));
       final module = SimpleModule();
-      await container.registerModules(module, module.runtimeType);
-      expect(() => container.registerModules(module, module.runtimeType),
-          throwsA(isA<InitializationError>()));
+      await container.registerModules(module);
+      await container.registerModules(module);
+      expect(container.scopes.length, 1);
     });
 
     test(
-        'registerModules should register a module and create a ModuleInjectables with the providers',
+        'registerModules should register a module and create a [ModuleScope] with the providers',
         () async {
       final container = ModulesContainer(ApplicationConfig(
           host: 'localhost',
@@ -51,18 +51,18 @@ void main() {
           ),
           poweredByHeader: 'Serinus'));
       final module = SimpleModuleWithProvider();
-      await container.registerModules(module, module.runtimeType);
-      expect(container.modules.length, 1);
+      await container.registerModules(module);
+      expect(container.scopes.length, 1);
       expect(
           container
-              .getModuleInjectablesByToken(module.runtimeType.toString())
+              .getScope(container.moduleToken(module))
               .providers
               .length,
           1);
     });
 
     test(
-        'registerModule should register a module with injectables and create a ModuleInjectables with all the injectables',
+        'registerModule should register a module with injectables and create a [ModuleScope] with all the injectables',
         () async {
       final container = ModulesContainer(ApplicationConfig(
           host: 'localhost',
@@ -74,12 +74,12 @@ void main() {
           ),
           poweredByHeader: 'Serinus'));
       final module = SimpleModuleWithInjectables();
-      await container.registerModules(module, module.runtimeType);
-      expect(container.modules.length, 1);
-      final injectables =
-          container.getModuleInjectablesByToken(module.runtimeType.toString());
-      expect(injectables.providers.length, 1);
-      expect(injectables.middlewares.length, 1);
+      await container.registerModules(module);
+      expect(container.scopes.length, 1);
+      final scope =
+          container.getScope(container.moduleToken(module));
+      expect(scope.providers.length, 1);
+      expect(scope.middlewares.length, 1);
     });
 
     test(
@@ -94,7 +94,7 @@ void main() {
             poweredByHeader: 'Serinus',
           ),
           poweredByHeader: 'Serinus'));
-      expect(() => container.getModuleInjectablesByToken('NotRegisteredModule'),
+      expect(() => container.getScope('NotRegisteredModule'),
           throwsA(isA<ArgumentError>()));
     });
 
@@ -128,26 +128,26 @@ void main() {
           ),
           poweredByHeader: 'Serinus'));
       final module = SimpleModuleWithImportsAndInjects();
-      await container.registerModules(module, module.runtimeType);
+      await container.registerModules(module);
       await container.finalize(module);
-      expect(container.modules.length, 3);
+      expect(container.scopes.length, 3);
       final injectables =
-          container.getModuleInjectablesByToken(module.runtimeType.toString());
+          container.getScope(container.moduleToken(module));
       expect(injectables.middlewares.length, 1);
       expect(injectables.providers.length, 2);
       final t = ImportableModuleWithProvider;
       final subInjectables =
-          container.getModuleInjectablesByToken(t.toString());
+          container.getScope(t.toString());
       expect(injectables.middlewares.length, 1);
-      expect(subInjectables.providers.length, 2);
+      expect(subInjectables.providers.length, 1);
       expect(
           injectables.providers.where((e) =>
               e.runtimeType == subInjectables.providers.last.runtimeType),
           isNotEmpty);
       final t2 = ImportableModuleWithNonExportedProvider;
       final subInjectablesTwo =
-          container.getModuleInjectablesByToken(t2.toString());
-      expect(subInjectablesTwo.providers.length, 3);
+          container.getScope(t2.toString());
+      expect(subInjectablesTwo.providers.length, 1);
     });
   });
 }

--- a/packages/serinus/test/core/middlewares_test.dart
+++ b/packages/serinus/test/core/middlewares_test.dart
@@ -56,10 +56,10 @@ class TestController extends Controller {
   TestController({super.path = '/'}) {
     on(
         TestRoute(path: '/middleware'),
-        (context) async => {
+        (RequestContext context) async {
               context.res.headers['x-middleware'] =
-                  context.request.headers['x-middleware'],
-              'ok!'
+                  context.request.headers['x-middleware'] ?? '';
+              return 'ok!';
             });
     on(Route.get('/value/<v>'), (context) async => 'Hello, World!');
     on(Route.get('/request-event'), (context) async => 'Hello, World!');
@@ -111,10 +111,10 @@ void main() {
   group('$Middleware', () {
     SerinusApplication? app;
     TestRequestEvent r = TestRequestEvent();
+    final module = TestModule(controllers: [TestController()], middlewares: [r]);
     setUpAll(() async {
       app = await serinus.createApplication(
-          entrypoint:
-              TestModule(controllers: [TestController()], middlewares: [r]),
+          entrypoint: module,
           port: 8888,
           logLevels: {LogLevel.none});
       await app?.serve();

--- a/packages/serinus/test/core/module_test.dart
+++ b/packages/serinus/test/core/module_test.dart
@@ -35,11 +35,11 @@ void main() async {
         () async {
       final container = ModulesContainer(config);
       final module = TestModule(imports: [TestSubModule()]);
-      await container.registerModules(module, Type);
+      await container.registerModules(module);
 
       await container.finalize(module);
 
-      expect(container.modules.length, 2);
+      expect(container.scopes.length, 2);
     });
 
     test(
@@ -52,8 +52,7 @@ void main() async {
               TestModule(
                   imports: [TestSubModule()],
                   providers: [TestProviderExported()],
-                  exports: [TestProviderExported]),
-              TestModule)
+                  exports: [TestProviderExported]),)
           .catchError(
               (value) => expect(value.runtimeType, InitializationError));
     });
@@ -67,8 +66,7 @@ void main() async {
           .registerModules(
               TestModule(
                 imports: [TestModule()],
-              ),
-              TestModule)
+              ),)
           .catchError(
               (value) => expect(value.runtimeType, InitializationError));
     });
@@ -82,7 +80,7 @@ void main() async {
           TestSubModule(exports: [TestProviderExported])
         ],
       );
-      await container.registerModules(entrypoint, TestModule);
+      await container.registerModules(entrypoint);
 
       container.finalize(entrypoint).catchError(
           (value) => expect(value.runtimeType, InitializationError));
@@ -115,7 +113,7 @@ void main() async {
       final subModule = TestSubModule();
       final module = TestModule(imports: [subModule]);
 
-      await container.registerModules(module, TestModule);
+      await container.registerModules(module);
 
       await container.finalize(module);
 

--- a/packages/serinus/test/core/provider_test.dart
+++ b/packages/serinus/test/core/provider_test.dart
@@ -107,7 +107,7 @@ void main() async {
       final provider = TestProvider();
       final container = ModulesContainer(config);
 
-      await container.registerModules(TestModule(providers: [provider]), Type);
+      await container.registerModules(TestModule(providers: [provider]));
       expect(container.get<TestProvider>(), provider);
     });
 
@@ -116,9 +116,7 @@ void main() async {
         ''', () async {
       final container = ModulesContainer(config);
 
-      container
-          .registerModule(
-              TestModule(providers: [TestProvider(), TestProvider()]), Type)
+      await container.registerModules(TestModule(providers: [TestProvider(), TestProvider()]))
           .catchError((e) => expect(e.runtimeType, InitializationError));
     });
 
@@ -127,7 +125,7 @@ void main() async {
       final provider = TestProviderHooks();
       final container = ModulesContainer(config);
       final module = TestModule(providers: [provider]);
-      await container.registerModules(module, Type);
+      await container.registerModules(module);
       await container.finalize(module);
       expect(provider.isInitialized, true);
     });
@@ -142,10 +140,9 @@ void main() async {
           DeferredProvider(() async => TestProvider(),
               inject: [], type: TestProvider)
         ]);
-        await container.registerModules(module, Type);
+        await container.registerModules(module);
 
         await container.finalize(module);
-
         expect(container.get<TestProvider>(), isNotNull);
       },
     );
@@ -158,7 +155,7 @@ void main() async {
           DeferredProvider(() async => TestProvider(),
               inject: [], type: TestProvider)
         ]);
-        await container.registerModules(module, Type);
+        await container.registerModules(module);
 
         expect(container.get<TestProvider>(), isNull);
       },
@@ -177,7 +174,7 @@ void main() async {
           return TestProviderDependent2(provider);
         }, inject: [TestProvider], type: TestProviderDependent2)
       ]);
-      await container.registerModules(module, Type);
+      await container.registerModules(module);
 
       await container.finalize(module);
 
@@ -194,7 +191,7 @@ void main() async {
           return TestProviderDependent(provider);
         }, inject: [TestProvider], type: TestProviderDependent)
       ]);
-      await container.registerModules(module, Type);
+      await container.registerModules(module);
 
       container.finalize(module).catchError(
           (value) => expect(value.runtimeType, InitializationError));
@@ -210,7 +207,7 @@ void main() async {
               inject: [], type: TestProviderDependent);
         }, inject: [TestProvider], type: TestProviderDependent)
       ]);
-      await container.registerModules(module, Type);
+      await container.registerModules(module);
 
       container.finalize(module).catchError(
           (value) => expect(value.runtimeType, InitializationError));
@@ -226,7 +223,7 @@ void main() async {
           return TestProviderDependent(provider);
         }, inject: [TestProvider], type: int)
       ]);
-      await container.registerModules(module, Type);
+      await container.registerModules(module);
 
       container.finalize(module).catchError((value) {
         expect(value.runtimeType, InitializationError);
@@ -247,7 +244,7 @@ void main() async {
           return TestProvider();
         }, inject: [], type: TestProvider),
       ]);
-      await container.registerModules(module, Type);
+      await container.registerModules(module);
 
       container.finalize(module).then(
           (_) => expect(container.get<TestProviderDependent>(), isNotNull));
@@ -265,7 +262,7 @@ void main() async {
           return CircularProvider2(provider);
         }, inject: [CircularProvider], type: CircularProvider2)
       ]);
-      await container.registerModules(module, Type);
+      await container.registerModules(module);
 
       container.finalize(module).catchError((value) {
         expect(value.runtimeType, InitializationError);
@@ -285,7 +282,7 @@ void main() async {
           return TestProviderDependent(provider);
         }, inject: [TestProvider], type: TestProviderDependent)
       ]);
-      await container.registerModules(module, Type);
+      await container.registerModules(module);
 
       container.finalize(module).catchError(
           (value) => expect(value.runtimeType, InitializationError));
@@ -300,7 +297,7 @@ void main() async {
           return 'not a provider';
         }, inject: [], type: TestProviderDependent)
       ]);
-      await container.registerModules(module, Type);
+      await container.registerModules(module);
 
       container.finalize(module).catchError(
           (value) => expect(value.runtimeType, InitializationError));

--- a/packages/serinus/test/core/tracer_test.dart
+++ b/packages/serinus/test/core/tracer_test.dart
@@ -139,7 +139,7 @@ void main() {
       final response = await request.close();
       expect(response.headers.value('duration'), isNotNull);
       expect(int.tryParse(response.headers.value('duration') ?? ''),
-          greaterThanOrEqualTo(100));
+          greaterThanOrEqualTo(1));
     });
   });
 }

--- a/packages/serinus/test/injector/explorer_test.dart
+++ b/packages/serinus/test/injector/explorer_test.dart
@@ -25,8 +25,8 @@ void main() {
       
       final router = Router();
       final modulesContainer = ModulesContainer(config);
-      await modulesContainer.registerModule(
-          SimpleMockModule(controllers: [MockController()]), SimpleMockModule);
+      await modulesContainer.registerModules(
+          SimpleMockModule(controllers: [MockController()]));
       final explorer = Explorer(modulesContainer, router, config);
       explorer.resolveRoutes();
     });
@@ -36,9 +36,8 @@ void main() {
         () async {
       final router = Router();
       final modulesContainer = ModulesContainer(config);
-      await modulesContainer.registerModule(
-          SimpleMockModule(controllers: [MockControllerWithWrongPath()]),
-          SimpleMockModule);
+      await modulesContainer.registerModules(
+          SimpleMockModule(controllers: [MockControllerWithWrongPath()]),);
       final explorer = Explorer(modulesContainer, router, config);
       expect(() => explorer.resolveRoutes(), throwsException);
     });
@@ -68,8 +67,8 @@ void main() {
           VersioningOptions(type: VersioningType.uri, version: 1);
       final router = Router();
       final modulesContainer = ModulesContainer(config);
-      await modulesContainer.registerModule(
-          SimpleMockModule(controllers: [MockController()]), SimpleMockModule);
+      await modulesContainer.registerModules(
+          SimpleMockModule(controllers: [MockController()]));
       final explorer = Explorer(modulesContainer, router, config);
       explorer.resolveRoutes();
       final result = router.getRouteByPathAndMethod('/v1', HttpMethod.get);
@@ -92,8 +91,8 @@ void main() {
       config.globalPrefix = GlobalPrefix(prefix: 'api');
       final router = Router();
       final modulesContainer = ModulesContainer(config);
-      await modulesContainer.registerModule(
-          SimpleMockModule(controllers: [MockController()]), SimpleMockModule);
+      await modulesContainer.registerModules(
+          SimpleMockModule(controllers: [MockController()]));
       final explorer = Explorer(modulesContainer, router, config);
       explorer.resolveRoutes();
       final result = router.getRouteByPathAndMethod('/api', HttpMethod.get);
@@ -181,8 +180,8 @@ void main() {
           VersioningOptions(type: VersioningType.uri, version: 1);
       final router = Router();
       final modulesContainer = ModulesContainer(config);
-      await modulesContainer.registerModule(
-          SimpleMockModule(controllers: [MockController()]), SimpleMockModule);
+      await modulesContainer.registerModules(
+          SimpleMockModule(controllers: [MockController()]));
       final explorer = Explorer(modulesContainer, router, config);
       explorer.resolveRoutes();
       final result = router.getRouteByPathAndMethod('/api/v1', HttpMethod.get);


### PR DESCRIPTION
# Description

The result from the `registerAsync` method in the Module class should be an expansion of the Module not a replacement. For this reason this PR introduces the DynamicModule, an utility class that will be used just to expand the Module in its scope.

Also the PR contains a full refactor of the Dependency Injection system allowing for a more deterministic approach thanks to the ModuleScope class and to the deletion of futile functions.

Fixes #152 

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

