### PR TITLE
fix(cli_warning_port): remove default value from port when using cli,…

### DIFF
--- a/packages/serinus/example/config.yaml
+++ b/packages/serinus/example/config.yaml
@@ -1,3 +1,0 @@
-# This file is used to configure the cli.
-# Do not modify the contents of this file.
-entrypoint: bin/echo.dart

--- a/packages/serinus/example/lib/serinus.dart
+++ b/packages/serinus/example/lib/serinus.dart
@@ -6,6 +6,6 @@ import 'app_module.dart';
 /// This function creates an application and serves it.
 Future<void> bootstrap() async {
   final app = await serinus.createApplication(
-      entrypoint: AppModule(), host: '0.0.0.0', port: 3000);
+      entrypoint: AppModule(), host: '0.0.0.0', port: 4000);
   await app.serve();
 }

--- a/packages/serinus_cli/CHANGELOG.md
+++ b/packages/serinus_cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.7
+
+- fix
+
 ## 1.0.6
 
 - fix(#180): Prevent the cli from overwriting already existing files when running the `generate` command.

--- a/packages/serinus_cli/lib/src/commands/run/run_command.dart
+++ b/packages/serinus_cli/lib/src/commands/run/run_command.dart
@@ -84,13 +84,15 @@ class RunCommand extends Command<int> {
     final mainFile = File(
       path.join(Directory.current.path, entrypoint),
     );
+    final port = argResults?['port'] as String?;
+    final host = argResults?['host'] as String?;
     final process = await Process.start(
       'dart',
       ['--enable-vm-service', mainFile.absolute.path],
       runInShell: true,
       environment: {
-        'PORT': argResults?['port'] as String? ?? '3000',
-        'HOST': argResults?['host'] as String? ?? 'localhost',
+        if(port != null) 'PORT': port,
+        if(host != null) 'HOST': host,
       },
     );
     progress?.complete();

--- a/packages/serinus_cli/lib/src/utils/config.dart
+++ b/packages/serinus_cli/lib/src/utils/config.dart
@@ -5,7 +5,7 @@ import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart';
 
 Future<Map<String, dynamic>> getProjectConfiguration(Logger logger,
-    {bool deps = false}) async {
+    {bool deps = false,}) async {
   final pubspec = File(path.join(Directory.current.path, 'pubspec.yaml'));
   if (!pubspec.existsSync()) {
     logger.err('No pubspec.yaml file found');
@@ -20,8 +20,7 @@ Future<Map<String, dynamic>> getProjectConfiguration(Logger logger,
     Map<dynamic, dynamic>.fromEntries(pubspecYaml.entries)['serinus'] as Map? ??
         {},
   );
-  if (pubspecMap.isEmpty) {
-    logger.warn('No serinus configuration found in pubspec.yaml');
+  if (pubspecMap.isEmpty || !pubspecMap.containsKey('entrypoint')) {
     pubspecMap['entrypoint'] =
         'bin/${pubspecYaml['name'] as String? ?? 'serinus_app'}.dart';
   }

--- a/packages/serinus_cli/lib/src/version.dart
+++ b/packages/serinus_cli/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '1.0.6';
+const packageVersion = '1.0.7';

--- a/packages/serinus_cli/pubspec.yaml
+++ b/packages/serinus_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: serinus_cli
 description: The official CLI of the Serinus Framework. It allows you to create, build, and manage Serinus projects.
-version: 1.0.6
+version: 1.0.7
 repository: 'https://github.com/francescovallone/serinus'
 homepage: https://serinus.app
 


### PR DESCRIPTION
… remove warnings regarding missing config

# Description

The CLI right now "override" the port defined while creating the application the in the bootstrap methods, this behaviour is wrong and must be fixed. Also there is an annoying warning for the missing config.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

