### PR TITLE
fix(#187): debounce the events executing only the last one

### DIFF
--- a/packages/serinus_cli/CHANGELOG.md
+++ b/packages/serinus_cli/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 1.0.8 
+
+- fix(#187): debounce the events executing only the last one.
+
 ## 1.0.7
 
-- fix
+- fix(cli_warning_port): remove default value from port when using cli, remove warnings regarding missing config.
 
 ## 1.0.6
 

--- a/packages/serinus_cli/lib/src/commands/create/create_command.dart
+++ b/packages/serinus_cli/lib/src/commands/create/create_command.dart
@@ -99,8 +99,9 @@ class CreateCommand extends Command<int> {
         defaultValue: '',
       ),
     };
-    if(outputDirectory.existsSync() && !force) {
-      _logger?.err('Directory already exists at ${outputDirectory.absolute.path}');
+    if (outputDirectory.existsSync() && !force) {
+      _logger
+          ?.err('Directory already exists at ${outputDirectory.absolute.path}');
       return;
     }
     if (!outputDirectory.existsSync()) {
@@ -150,8 +151,9 @@ class CreateCommand extends Command<int> {
         defaultValue: 'A new Serinus application',
       ),
     };
-    if(outputDirectory.existsSync() && !force) {
-      progress?.fail('Directory already exists at ${outputDirectory.absolute.path}');
+    if (outputDirectory.existsSync() && !force) {
+      progress?.fail(
+          'Directory already exists at ${outputDirectory.absolute.path}');
       return;
     }
     if (!outputDirectory.existsSync()) {

--- a/packages/serinus_cli/lib/src/commands/deploy_command.dart
+++ b/packages/serinus_cli/lib/src/commands/deploy_command.dart
@@ -78,10 +78,11 @@ class DeployCommand extends Command<int> {
   ) async {
     final client = HttpClient();
     final request = await client.getUrl(
-      Uri.parse('https://raw.githubusercontent.com/francescovallone/serinus/refs/heads/main/utils/Dockerfile.base'),
+      Uri.parse(
+          'https://raw.githubusercontent.com/francescovallone/serinus/refs/heads/main/utils/Dockerfile.base'),
     );
     final response = await request.close();
-    if(response.statusCode != 200) {
+    if (response.statusCode != 200) {
       _logger.err(
         'Failed to fetch Dockerfile from repository fallback to cli version',
       );
@@ -93,7 +94,7 @@ class DeployCommand extends Command<int> {
         .replaceAll('{{$output}}', output)
         .replaceAll('{{$port}}', port);
 
-    return dockerFileContent;    
+    return dockerFileContent;
   }
 
   String dockerFile(

--- a/packages/serinus_cli/lib/src/commands/generate/generate_command.dart
+++ b/packages/serinus_cli/lib/src/commands/generate/generate_command.dart
@@ -154,8 +154,13 @@ class _GenerateController extends GenerateItemCommand {
 
   @override
   Future<int> run() async {
-    await generateItem(itemName, _item, logger, analyzer, 
-        overwrite: argResults['force'] as bool,);
+    await generateItem(
+      itemName,
+      _item,
+      logger,
+      analyzer,
+      overwrite: argResults['force'] as bool,
+    );
     return ExitCode.success.code;
   }
 }
@@ -180,8 +185,13 @@ class _GenerateModule extends GenerateItemCommand {
 
   @override
   Future<int> run() async {
-    await generateItem(itemName, _item, logger, analyzer, 
-        overwrite: argResults['force'] as bool,);
+    await generateItem(
+      itemName,
+      _item,
+      logger,
+      analyzer,
+      overwrite: argResults['force'] as bool,
+    );
     return ExitCode.success.code;
   }
 }
@@ -206,12 +216,27 @@ class _GenerateResource extends GenerateItemCommand {
 
   @override
   Future<int> run() async {
-    await generateItem('module', _item, logger, analyzer, 
-        overwrite: argResults['force'] as bool,);
-    await generateItem('provider', _item, logger, analyzer, 
-        overwrite: argResults['force'] as bool,);
-    await generateItem('controller', _item, logger, analyzer, 
-        overwrite: argResults['force'] as bool,);
+    await generateItem(
+      'module',
+      _item,
+      logger,
+      analyzer,
+      overwrite: argResults['force'] as bool,
+    );
+    await generateItem(
+      'provider',
+      _item,
+      logger,
+      analyzer,
+      overwrite: argResults['force'] as bool,
+    );
+    await generateItem(
+      'controller',
+      _item,
+      logger,
+      analyzer,
+      overwrite: argResults['force'] as bool,
+    );
     return ExitCode.success.code;
   }
 }
@@ -236,8 +261,13 @@ class _GenerateProvider extends GenerateItemCommand {
 
   @override
   Future<int> run() async {
-    await generateItem(itemName, _item, logger, analyzer, 
-        overwrite: argResults['force'] as bool,);
+    await generateItem(
+      itemName,
+      _item,
+      logger,
+      analyzer,
+      overwrite: argResults['force'] as bool,
+    );
     return ExitCode.success.code;
   }
 }
@@ -246,9 +276,9 @@ Future<void> generateItem(
   String type,
   ReCase name,
   Logger? logger,
-  SerinusAnalyzer analyzer,
-  {bool overwrite = false,}
-) async {
+  SerinusAnalyzer analyzer, {
+  bool overwrite = false,
+}) async {
   final outputDirectory = Directory(
     path.join(Directory.current.path, 'lib'),
   );

--- a/packages/serinus_cli/lib/src/commands/generate/generator/generator.dart
+++ b/packages/serinus_cli/lib/src/commands/generate/generator/generator.dart
@@ -80,7 +80,10 @@ class Generator {
     }
   }
 
-  Future<({String elementName, bool generated})> generateController(GeneratedElement element, {bool overwrite = false,}) async {
+  Future<({String elementName, bool generated})> generateController(
+    GeneratedElement element, {
+    bool overwrite = false,
+  }) async {
     final newController = Library((b) {
       b.directives.add(Directive.import('package:serinus/serinus.dart'));
       b.body.add(
@@ -115,7 +118,8 @@ class Generator {
     });
     final fileName = '${itemName.getSnakeCase()}_controller.dart';
     final filePath = '${fileName.split('_').first}/$fileName';
-    if (File('${outputDirectory.absolute.path}/$filePath').existsSync() && !overwrite) {
+    if (File('${outputDirectory.absolute.path}/$filePath').existsSync() &&
+        !overwrite) {
       return (
         elementName: element.name,
         generated: false,
@@ -137,7 +141,10 @@ class Generator {
     );
   }
 
-  Future<bool> generateModule(GeneratedElement element, {bool overwrite = false,}) async {
+  Future<bool> generateModule(
+    GeneratedElement element, {
+    bool overwrite = false,
+  }) async {
     final emitter = DartEmitter(
       allocator: Allocator(),
       orderDirectives: true,
@@ -179,7 +186,9 @@ class Generator {
     return true;
   }
 
-  Future<({String elementName, bool generated})> generateProvider(GeneratedElement element, {bool overwrite = false}) async {
+  Future<({String elementName, bool generated})> generateProvider(
+      GeneratedElement element,
+      {bool overwrite = false}) async {
     final emitter = DartEmitter(
       allocator: Allocator(),
       orderDirectives: true,

--- a/packages/serinus_cli/lib/src/commands/run/run_command.dart
+++ b/packages/serinus_cli/lib/src/commands/run/run_command.dart
@@ -68,7 +68,6 @@ class RunCommand extends Command<int> {
     final subscription =
         _watcher.events.where((_) => _developmentMode).listen((event) async {
       if (event.type == ChangeType.MODIFY) {
-        
         if (restarting) {
           restartQueue.add(event);
           return;
@@ -79,7 +78,7 @@ class RunCommand extends Command<int> {
         print('\x1B[2J\x1B[0;0H');
         process = await serve(entrypoint, restarting: true);
         restarting = false;
-        if(restartQueue.isNotEmpty) {
+        if (restartQueue.isNotEmpty) {
           final nextEvent = restartQueue.removeLast();
           if (nextEvent.type == ChangeType.MODIFY) {
             await _killProcess(process, restarting: true);
@@ -110,8 +109,8 @@ class RunCommand extends Command<int> {
       ['--enable-vm-service', mainFile.absolute.path],
       runInShell: true,
       environment: {
-        if(port != null) 'PORT': port,
-        if(host != null) 'HOST': host,
+        if (port != null) 'PORT': port,
+        if (host != null) 'HOST': host,
       },
     );
     progress?.complete();

--- a/packages/serinus_cli/lib/src/commands/run/run_command.dart
+++ b/packages/serinus_cli/lib/src/commands/run/run_command.dart
@@ -1,3 +1,4 @@
+import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
 
@@ -62,13 +63,31 @@ class RunCommand extends Command<int> {
         _killProcess(process);
       });
     }
+    var restarting = false;
+    final restartQueue = Queue<WatchEvent>();
     final subscription =
         _watcher.events.where((_) => _developmentMode).listen((event) async {
       if (event.type == ChangeType.MODIFY) {
+        
+        if (restarting) {
+          restartQueue.add(event);
+          return;
+        }
+        restarting = true;
         await _killProcess(process, restarting: true);
         // ignore: avoid_print
         print('\x1B[2J\x1B[0;0H');
         process = await serve(entrypoint, restarting: true);
+        restarting = false;
+        if(restartQueue.isNotEmpty) {
+          final nextEvent = restartQueue.removeLast();
+          if (nextEvent.type == ChangeType.MODIFY) {
+            await _killProcess(process, restarting: true);
+            // ignore: avoid_print
+            print('\x1B[2J\x1B[0;0H');
+            process = await serve(entrypoint, restarting: true);
+          }
+        }
       }
     });
 

--- a/packages/serinus_cli/lib/src/utils/config.dart
+++ b/packages/serinus_cli/lib/src/utils/config.dart
@@ -4,8 +4,10 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart';
 
-Future<Map<String, dynamic>> getProjectConfiguration(Logger logger,
-    {bool deps = false,}) async {
+Future<Map<String, dynamic>> getProjectConfiguration(
+  Logger logger, {
+  bool deps = false,
+}) async {
   final pubspec = File(path.join(Directory.current.path, 'pubspec.yaml'));
   if (!pubspec.existsSync()) {
     logger.err('No pubspec.yaml file found');

--- a/packages/serinus_cli/lib/src/version.dart
+++ b/packages/serinus_cli/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '1.0.7';
+const packageVersion = '1.0.8';

--- a/packages/serinus_cli/pubspec.yaml
+++ b/packages/serinus_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: serinus_cli
 description: The official CLI of the Serinus Framework. It allows you to create, build, and manage Serinus projects.
-version: 1.0.7
+version: 1.0.8
 repository: 'https://github.com/francescovallone/serinus'
 homepage: https://serinus.app
 


### PR DESCRIPTION
# Description

The event listener now populates a queue when busy restarting the appliocation and then takes the last event saved and execute another hot restart with that one.

Fixes #187 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

