### PR TITLE
fix(#189): await for the exit code after killing the process

### DIFF
--- a/packages/serinus_cli/CHANGELOG.md
+++ b/packages/serinus_cli/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.9
 
-- 
+- fix(#189): await for `Process.exitCode` after killing the process in Linux and MacOS. [#190](https://github.com/francescovallone/serinus/pull/190) by [francescovallone](https://github.com/francescovallone)
 
 ## 1.0.8 
 

--- a/packages/serinus_cli/CHANGELOG.md
+++ b/packages/serinus_cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.9
+
+- 
+
 ## 1.0.8 
 
 - fix(#187): debounce the events executing only the last one.

--- a/packages/serinus_cli/lib/src/version.dart
+++ b/packages/serinus_cli/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '1.0.8';
+const packageVersion = '1.0.9';

--- a/packages/serinus_cli/pubspec.yaml
+++ b/packages/serinus_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: serinus_cli
 description: The official CLI of the Serinus Framework. It allows you to create, build, and manage Serinus projects.
-version: 1.0.8
+version: 1.0.9
 repository: 'https://github.com/francescovallone/serinus'
 homepage: https://serinus.app
 


### PR DESCRIPTION
# Description

Await for the exitCode of the process after killing the process to prevent race conditioning

Fixes #189

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

