### PR TITLE
fix: gentle close the web socket connections when application shuts down

### DIFF
--- a/packages/serinus/lib/src/adapters/ws_adapter.dart
+++ b/packages/serinus/lib/src/adapters/ws_adapter.dart
@@ -124,7 +124,7 @@ abstract class WsAdapter extends Adapter<Map<String, WebSocket>> {
       serverSide: true,
     );
     if (result == null || result.values.isEmpty) {
-      webSocket.close(
+      await webSocket.close(
         normalClosure,
         'No gateway found for the path: ${request.uri}',
       );
@@ -188,6 +188,9 @@ abstract class WsAdapter extends Adapter<Map<String, WebSocket>> {
 
   @override
   Future<void> close() async {
+    for (final client in [...(server?.values ?? <WebSocket>[])]) {
+      await client.close(normalClosure, 'Server is shutting down');
+    }
     server?.clear();
   }
 }


### PR DESCRIPTION
# Description

The WebSocket connections should be gently closed when the application shuts down.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

