### PR TITLE
feat: add bodyAsList<T>() to parse lists of elements

### DIFF
--- a/.website/controllers.md
+++ b/.website/controllers.md
@@ -173,9 +173,13 @@ As you can see in the example above, we have defined the type of the request bod
 When using custom objects as request body types, make sure to register a `ModelProvider` that can handle the serialization and deserialization of your models.
 :::
 
+> [!IMPORTANT]
+> Right now Serinus supports only `List<dynamic>` and `List<Map<String, dynamic>>` as request body types for lists. Support for custom object lists will be added in future releases. The reason behind this limitation is that Dart's type system does not support generic type parameters at runtime, making it impossible to determine the type of the objects in the list.
+
 ### Parse the body in the handler
 
 You can define the type of the request body by using the `bodyAs<T>()` method of the `RequestContext` object. This method will parse the body of the request and return an instance of the specified type.
+If you expect a list of objects, you can use the `bodyAsList<T>()` method instead this is a workaround until Serinus supports custom object lists as request body types.
 
 If you have defined the `ModelProvider` to handle the serialization and deserialization of your models, you can use this method to get the body as an instance of your model. 
 
@@ -192,15 +196,18 @@ class UserController extends Controller {
     final newUser = await context.use<UsersService>().createUser(body);
     return newUser;
   }
+
+  Future<List<User>> createBatchUsers(RequestContext context) async {
+    final body = context.bodyAsList<UserCreate>(); // List<UserCreate>
+    final newUsers = await context.use<UsersService>().createBatchUsers(body);
+    return newUsers;
+  }
 }
 ```
 
 ::: info
 Although both approaches are valid, using the first approach (defining the type in the method signature) is generally preferred as it provides better type safety and makes the code more readable.
 :::
-
-> [!IMPORTANT]
-> Right now Serinus supports only `List<dynamic>` and `List<Map<String, dynamic>>` as request body types for lists. Support for custom object lists will be added in future releases. The reason behind this limitation is that Dart's type system does not support generic type parameters at runtime, making it impossible to determine the type of the objects in the list.
 
 ## Path Parameters
 

--- a/packages/serinus/lib/src/contexts/request_context.dart
+++ b/packages/serinus/lib/src/contexts/request_context.dart
@@ -147,6 +147,18 @@ class RequestContext<TBody> extends BaseContext {
   /// Casts the current body to a different type.
   T bodyAs<T>() => _converter.convert(_typeOf<T>(), body) as T;
 
+  /// Casts the current body to a list of a different type.
+  List<T> bodyAsList<T>() {
+    if (body is! List) {
+      throw BadRequestException('The element is not of the expected type');
+    }
+    return List<T>.from(
+      (body as List).map(
+        (e) => _converter.convert(_typeOf<T>(), e) as T,
+      ),
+    );
+  }
+
   /// Replaces the underlying body, reusing the conversion rules.
   void replaceBody(Object? value) => body = value;
 

--- a/packages/serinus/test/http/typed_body_test.dart
+++ b/packages/serinus/test/http/typed_body_test.dart
@@ -114,6 +114,26 @@ void main() {
       expect((body.first as Map<String, dynamic>)['name'], equals('serinus'));
     });
 
+    test('casts dynamic list to typed list of strings by using bodyAsList', () {
+      final request = _buildRequest();
+      final context = RequestContext<dynamic>.withBody(
+        request,
+        [
+          'data',
+          'info',
+          'serinus',
+        ],
+        <Type, Provider>{},
+        <Type, Object>{},
+      );
+
+      final body = context.bodyAsList<String>();
+
+      expect(body, hasLength(3));
+      expect(body.first, isA<String>());
+      expect(body.last, equals('serinus'));
+    });
+
     test('throws when body cannot be converted to expected type', () {
       final request = _buildRequest();
       final context = RequestContext<dynamic>.withBody(


### PR DESCRIPTION
# Description

Add `bodyAsList<T>` as a workaround for Dart generics issue that prevent the typed handler to parse the list body.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

