### PR TITLE
fix: OpenAPI UI not rendering when `analyze: false` in production

### DIFF
--- a/packages/serinus_openapi/lib/src/open_api_registry.dart
+++ b/packages/serinus_openapi/lib/src/open_api_registry.dart
@@ -86,8 +86,7 @@ class OpenApiRegistry extends Provider with OnApplicationBootstrap {
     }
     if (!analyze) {
       if (file.existsSync()) {
-        _content = file.readAsStringSync();
-        _generateOpenApiDocument(
+        _content = _generateOpenApiDocument(
           file,
           '$savedFilePath',
           reuseCurrentFile: true,


### PR DESCRIPTION
# Description

This PR fixes a bug where OpenAPI documentation returns raw YAML/JSON instead of the rendered HTML UI when `analyze: false` is set (common in production/serverless environments).

Fixes https://github.com/francescovallone/serinus/issues/206

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

