### PR TITLE
feat(serinus_microservices)!: treat controllers like interceptors in gRPC microservices

### DIFF
--- a/examples/grpc_example/lib/generated/helloworld.pb.dart
+++ b/examples/grpc_example/lib/generated/helloworld.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 
@@ -56,8 +56,6 @@ class HelloRequest extends $pb.GeneratedMessage {
   static HelloRequest create() => HelloRequest._();
   @$core.override
   HelloRequest createEmptyInstance() => create();
-  static $pb.PbList<HelloRequest> createRepeated() =>
-      $pb.PbList<HelloRequest>();
   @$core.pragma('dart2js:noInline')
   static HelloRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<HelloRequest>(create);
@@ -112,7 +110,6 @@ class HelloReply extends $pb.GeneratedMessage {
   static HelloReply create() => HelloReply._();
   @$core.override
   HelloReply createEmptyInstance() => create();
-  static $pb.PbList<HelloReply> createRepeated() => $pb.PbList<HelloReply>();
   @$core.pragma('dart2js:noInline')
   static HelloReply getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<HelloReply>(create);

--- a/examples/grpc_example/lib/generated/helloworld.pbenum.dart
+++ b/examples/grpc_example/lib/generated/helloworld.pbenum.dart
@@ -8,4 +8,4 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/examples/grpc_example/lib/generated/helloworld.pbgrpc.dart
+++ b/examples/grpc_example/lib/generated/helloworld.pbgrpc.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:async' as $async;
 import 'dart:core' as $core;

--- a/examples/grpc_example/lib/generated/helloworld.pbjson.dart
+++ b/examples/grpc_example/lib/generated/helloworld.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/examples/grpc_example/pubspec.yaml
+++ b/examples/grpc_example/pubspec.yaml
@@ -5,14 +5,13 @@ publish_to: none
 environment:
   sdk: '>=3.9.0 <4.0.0'
 
-resolution: workspace
-
 dependencies:
   serinus: ^2.0.0
   dio: ^5.7.0
   protobuf: ^6.0.0
   grpc: ^5.1.0
-  serinus_microservices: ^0.1.0
+  serinus_microservices: 
+    path: ../../packages/serinus_microservices
 dev_dependencies:
   build_runner: ^2.4.12
   

--- a/packages/serinus_microservices/lib/transporters/grpc/grpc_message_handler.dart
+++ b/packages/serinus_microservices/lib/transporters/grpc/grpc_message_handler.dart
@@ -1,49 +1,9 @@
+import 'dart:async';
+
 import 'package:grpc/grpc.dart';
 import 'package:serinus/serinus.dart';
 import 'grpc_controller.dart';
-
-/// The [GrpcPayload] class is the gRPC payload.
-sealed class GrpcPayload<T, R> {
-  /// The gRPC service call.
-  final ServiceCall call;
-
-  /// The future request.
-  final T futureRequest;
-
-  /// Creates a gRPC payload.
-  GrpcPayload(this.call, this.futureRequest);
-
-  /// Gets the request.
-  T getRequest();
-}
-
-/// The [GrpcPayloadUnitary] class is the gRPC unary payload.
-class GrpcPayloadUnitary<O> extends GrpcPayload<Future<O>, O> {
-  /// Creates a gRPC unary payload.
-  GrpcPayloadUnitary(ServiceCall call, Future<O> futureRequest) : super(call, futureRequest);
-
-  O? _request;
-
-  @override
-  Future<O> getRequest() async {
-    if (_request != null) {
-      return _request!;
-    }
-    _request = await futureRequest;
-    return _request!;
-  }
-}
-
-/// The [GrpcPayloadStream] class is the gRPC stream payload.
-class GrpcPayloadStream<O> extends GrpcPayload<Stream<O>, O> {
-  /// Creates a gRPC stream payload.
-  GrpcPayloadStream(ServiceCall call, Stream<O> futureRequest) : super(call, futureRequest);
-
-  @override
-  Stream<O> getRequest() async* {
-    yield* futureRequest;
-  }
-}
+import 'grpc_payload.dart';
 
 /// The [GrpcRouteContext] class is the gRPC route context.
 sealed class GrpcRouteContext<T> {
@@ -110,6 +70,8 @@ class GrpcMessageResolver extends MessagesResolver {
   /// The [resolvedAlready] property is used to check if the routes have been resolved already.
   bool resolvedAlready = false;
 
+  final Logger _logger = Logger('GrpcMessageResolver');
+
   /// The [GrpcMessageResolver] constructor is used to create a new instance of the [MessagesResolver] class.
   GrpcMessageResolver(super.config, this.services);
 
@@ -121,21 +83,23 @@ class GrpcMessageResolver extends MessagesResolver {
     for (final module in config.modulesContainer.scopes) {
       for (final controllerEntry in module.controllers.whereType<GrpcController>()) {
         for (final entry in controllerEntry.grpcRoutes.entries) {
-          if (resolvedMessageRoutes.containsKey(entry.value.route.path)) {
+          final grpcRoute = entry.value.route as GrpcRoute;
+          if (resolvedMessageRoutes.containsKey(grpcRoute.path)) {
             throw StateError(
-              'A message route with pattern "${entry.value.route.path}" is already registered in the application.',
+              'A message route with pattern "${grpcRoute.path}" is already registered in the application.',
             );
           }
-          final service = entry.value.route.path.split('.').first;
+          final routeInfo = grpcRoute.path.split('.');
+          final service = routeInfo.first;
           final serviceNames = services.map((e) => e.runtimeType.toString());
           if (!serviceNames.contains(service)) {
             throw StateError(
-              'Service "$service" for gRPC route "${entry.value.route.path}" is not registered in the gRPC server.',
+              'Service "$service" for gRPC route "${grpcRoute.path}" is not registered in the gRPC server.',
             );
           }
           switch (entry.value) {
             case GrpcRouteHandlerSpec():
-              resolvedMessageRoutes[entry.value.route.path] = GrpcRouteContextHandler(
+              resolvedMessageRoutes[grpcRoute.path] = GrpcRouteContextHandler(
                 handler: entry.value.handler,
                 providers: {
                   for (final providerEntry in module.providers) providerEntry.runtimeType: providerEntry,
@@ -154,6 +118,9 @@ class GrpcMessageResolver extends MessagesResolver {
                   ...controllerEntry.exceptionFilters,
                   ...config.globalExceptionFilters,
                 },
+              );
+              _logger.info(
+                'Mapped {${grpcRoute.serviceName}, ${grpcRoute.methodName}} route',
               );
               break;
             case GrpcStreamRouteHandlerSpec():
@@ -176,6 +143,9 @@ class GrpcMessageResolver extends MessagesResolver {
                   ...controllerEntry.exceptionFilters,
                   ...config.globalExceptionFilters,
                 },
+              );
+              _logger.info(
+                'Mapped {${grpcRoute.serviceName}, ${grpcRoute.methodName}} route',
               );
               break;
             default:
@@ -211,20 +181,48 @@ class GrpcMessageResolver extends MessagesResolver {
       for (final pipe in routeContext.pipes) {
         await pipe.transform(executionContext);
       }
-      final grpcPayload = packet.payload as GrpcPayload;
+      final grpcPayload = packet.payload as GrpcPayload<dynamic, dynamic, dynamic>;
       final call = grpcPayload.call;
-      final request = await grpcPayload.getRequest();
-      final result = await routeContext.handler(
-        call,
-        request,
-        executionContext.switchToRpc(),
-      );
-      if (packet.id != null) {
-        return ResponsePacket(
-          pattern: packet.pattern,
-          id: packet.id,
-          payload: result,
+
+      if (routeContext.streaming) {
+        final originalStream = grpcPayload.getRequest() as Stream<dynamic>;
+        final transformed = await Future.value(
+          routeContext.handler(
+            call,
+            originalStream,
+            executionContext.switchToRpc(),
+          ),
         );
+        final Stream<dynamic> forwardedStream = transformed is Stream ? transformed : originalStream;
+        final responseStream = grpcPayload.invoke(grpcPayload.coerceStream(forwardedStream));
+        if (packet.id != null) {
+          return ResponsePacket(
+            pattern: packet.pattern,
+            id: packet.id,
+            payload: responseStream,
+          );
+        }
+      } else {
+        final originalRequest = await (grpcPayload.getRequest() as Future<dynamic>);
+        final handler = routeContext.handler as dynamic;
+        final Object? transformed = await Future<Object?>.value(
+          handler(
+            call,
+            originalRequest,
+            executionContext.switchToRpc(),
+          ),
+        );
+        final forwardedRequest = transformed ?? originalRequest;
+        final coerced = grpcPayload.coerceSingle(forwardedRequest);
+        final responseStream = grpcPayload.invoke(Stream.value(coerced));
+        final response = grpcPayload.streamingResponse ? await responseStream.first : await responseStream.single;
+        if (packet.id != null) {
+          return ResponsePacket(
+            pattern: packet.pattern,
+            id: packet.id,
+            payload: response,
+          );
+        }
       }
     } on RpcException catch (e) {
       for (final filter in routeContext.exceptionFilters) {

--- a/packages/serinus_microservices/lib/transporters/grpc/grpc_payload.dart
+++ b/packages/serinus_microservices/lib/transporters/grpc/grpc_payload.dart
@@ -1,0 +1,82 @@
+import 'package:grpc/grpc.dart';
+
+/// The [GrpcPayload] class carries metadata and request stream for gRPC handlers.
+sealed class GrpcPayload<F, Q, R> {
+  /// The gRPC service call.
+  final ServiceCall call;
+
+  /// The raw incoming request representation (future or stream).
+  final F futureRequest;
+
+  /// The gRPC service method metadata.
+  final ServiceMethod<Q, R> method;
+
+  /// The gRPC invoker used to call the underlying service.
+  final ServerStreamingInvoker<Q, R> invoker;
+
+  /// Creates a gRPC payload.
+  GrpcPayload(
+    this.call,
+    this.futureRequest, {
+    required this.method,
+    required this.invoker,
+  });
+
+  /// True when the request is streaming.
+  bool get streamingRequest => method.streamingRequest;
+
+  /// True when the response is streaming.
+  bool get streamingResponse => method.streamingResponse;
+
+  /// Resolves the incoming request into the request type expected by the service.
+  dynamic getRequest();
+
+  /// Invokes the underlying service method using the invoker.
+  Stream<R> invoke(Stream<Q> requests) {
+    return invoker(call, method, requests);
+  }
+
+  /// Casts an incoming stream to the expected request type.
+  Stream<Q> coerceStream(Stream<dynamic> input) => input.cast<Q>();
+
+  /// Casts a single value to the expected request type.
+  Q coerceSingle(dynamic value) => value as Q;
+}
+
+/// The [GrpcPayloadUnitary] class is the gRPC unary payload.
+class GrpcPayloadUnitary<Q, R> extends GrpcPayload<Future<Q>, Q, R> {
+  /// Creates a gRPC unary payload.
+  GrpcPayloadUnitary(
+    ServiceCall call,
+    Future<Q> futureRequest, {
+    required super.method,
+    required super.invoker,
+  }) : super(call, futureRequest);
+
+  Q? _request;
+
+  @override
+  Future<Q> getRequest() async {
+    if (_request != null) {
+      return _request!;
+    }
+    _request = await futureRequest;
+    return _request!;
+  }
+}
+
+/// The [GrpcPayloadStream] class is the gRPC stream payload.
+class GrpcPayloadStream<Q, R> extends GrpcPayload<Stream<Q>, Q, R> {
+  /// Creates a gRPC stream payload.
+  GrpcPayloadStream(
+    ServiceCall call,
+    Stream<Q> futureRequest, {
+    required super.method,
+    required super.invoker,
+  }) : super(call, futureRequest);
+
+  @override
+  Stream<Q> getRequest() async* {
+    yield* futureRequest;
+  }
+}


### PR DESCRIPTION
# Description

Controllers now are treated as Interceptors in gRPC environment. This change is to ensure that the implemented Service is actually used and not treated like a template. It also removes code redundancy and improve the separation of concern.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional gRPC handlers with default passthrough behavior.

* **Refactor**
  * Simplified gRPC route handler API to use request-only type parameters instead of separate request and response types.
  * Enhanced payload abstraction for unified handling of unary and streaming request/response flows.
  * Improved gRPC path parsing and validation with better error messages.

* **Chores**
  * Updated gRPC example to use new handler patterns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->