### PR TITLE
fix(pipe_parsing): defer body conversion to allow pipes to actually transform and validate bodies

### DIFF
--- a/packages/serinus/bin/serinus.dart
+++ b/packages/serinus/bin/serinus.dart
@@ -122,6 +122,19 @@ class MyModelProvider extends ModelProvider {
   };
 }
 
+class MyPipe extends Pipe {
+  @override
+  Future<void> transform(ExecutionContext context) async {
+    print('MyPipe executed');
+    if (context.argumentsHost is HttpArgumentsHost) {
+      final reqContext = context.switchToHttp();
+      print('Request path: ${reqContext.request.path}');
+      print('Request body before transformation: ${reqContext.body}');
+      reqContext.body = {'name': 'bird', 'value': 42};
+    }
+  }
+}
+
 void main(List<String> arguments) async {
   final application = await serinus.createMinimalApplication(
     host: InternetAddress.anyIPv4.address,
@@ -129,9 +142,10 @@ void main(List<String> arguments) async {
     logger: ConsoleLogger(prefix: 'Serinus New Logger'),
     modelProvider: MyModelProvider(),
   );
+  application.use(MyPipe());
   application.provide(TestProvider());
-  application.get('/', (RequestContext context) async {
-    return context.use<TestProvider>().counter;
+  application.post('/', (RequestContext<MyObject> context) async {
+    return context.body;
   });
   await application.serve();
 }

--- a/packages/serinus/lib/src/adapters/ws_adapter.dart
+++ b/packages/serinus/lib/src/adapters/ws_adapter.dart
@@ -112,6 +112,12 @@ abstract class WsAdapter extends Adapter<Map<String, WebSocket>> {
     String clientId,
   ) async {
     final result = router?.lookup(HttpMethod.all, request.path);
+    if (result == null || result.values.isEmpty) {
+      response.status(HttpStatus.notFound);
+      response.send();
+      return;
+    }
+
     final socket = await response.detachSocket();
     final channel = StreamChannel<List<int>>(socket, socket);
     final sink = utf8.encoder.startChunkedConversion(channel.sink);
@@ -129,13 +135,6 @@ abstract class WsAdapter extends Adapter<Map<String, WebSocket>> {
       channel.sink as Socket,
       serverSide: true,
     );
-    if (result == null || result.values.isEmpty) {
-      await webSocket.close(
-        normalClosure,
-        'No gateway found for the path: ${request.uri}',
-      );
-      return;
-    }
     final gatewayScope = List<GatewayScope>.from(result.values).first;
     bindClientConnection(
       clientId: clientId,

--- a/packages/serinus/lib/src/contexts/execution_context.dart
+++ b/packages/serinus/lib/src/contexts/execution_context.dart
@@ -122,7 +122,17 @@ final class ExecutionContext<T extends ArgumentsHost> extends BaseContext {
     if (context == null) {
       throw StateError('The HTTP context has not been initialized');
     }
-    return context;
+    return RequestContext<dynamic>.withBody(
+        context.request,
+        context.rawBody,
+        providers,
+        values,
+        hooksServices,
+        explicitType: dynamic,
+        shouldValidateMultipart: context.shouldValidateMultipart,
+      )
+      ..metadata = metadata
+      ..response = response;
   }
 
   /// Attaches a pre-built [RequestContext] to the current execution context.

--- a/packages/serinus/lib/src/contexts/request_context.dart
+++ b/packages/serinus/lib/src/contexts/request_context.dart
@@ -30,13 +30,13 @@ class RequestContext<TBody> extends BaseContext {
   }) : request = httpRequest,
        _bodyType = explicitType ?? _typeOf<TBody>(),
        _body = body,
+       _bodyConverted = true,
        shouldValidateMultipart = shouldValidateMultipart,
        super(providers, values, hooksServices) {
     if (_converter?.modelProvider == null) {
       _converter = _BodyConverter(modelProvider);
     }
-    // Note: We retain the raw body initially. 
-    // The framework or user should call transformBody() to enforce TBody rules.
+    this.body = _converter?.convert(_bodyType, body);
   }
 
   RequestContext._(
@@ -47,6 +47,7 @@ class RequestContext<TBody> extends BaseContext {
     Map<Type, Provider> providers,
     Map<ValueToken, Object?> values,
     Map<Type, Object> hooksServices,
+    this._bodyConverted,
     bool shouldValidateMultipart,
   ) : _body = body,
       shouldValidateMultipart = shouldValidateMultipart,
@@ -81,6 +82,7 @@ class RequestContext<TBody> extends BaseContext {
         providers,
         values,
         hooksServices,
+        false,
         shouldValidateMultipart,
       );
     }
@@ -93,18 +95,16 @@ class RequestContext<TBody> extends BaseContext {
     } else {
       raw = null;
     }
-    
-    // Assign raw body without eager conversion to allow Pipes to validate it first.
     request.body = raw;
-    
     return RequestContext._(
       request,
       targetType,
       _converter,
-      raw,
+      request.body,
       providers,
       values,
       hooksServices,
+      explicitType == null,
       shouldValidateMultipart,
     );
   }
@@ -118,6 +118,8 @@ class RequestContext<TBody> extends BaseContext {
   final bool shouldValidateMultipart;
 
   Object? _body;
+
+  bool _bodyConverted;
 
   /// Returns the request path.
   String get path => request.path;
@@ -133,11 +135,23 @@ class RequestContext<TBody> extends BaseContext {
 
   /// Returns the unconverted, raw payload (e.g., Map<String, dynamic>).
   /// Use this inside Pipes for validation before the body is transformed into a DTO.
-  Object? get rawBody => _body;
+  Object? get rawBody => request.body;
 
   /// Returns the strongly typed body.
-  /// Throws a cast error if accessed before [transformBody] is called on a strict type.
+  ///
+  /// Before conversion is finalized, this returns the current raw payload.
+  /// Use [rawBody] when you explicitly need raw values in pipes.
   TBody get body {
+    if (!_bodyConverted &&
+        shouldValidateMultipart &&
+        request.contentType.isMultipart) {
+      throw StateError(
+        'The route has been marked with shouldValidateMultipart, use validateMultipartPart<T> before.',
+      );
+    }
+    if (!_bodyConverted) {
+      return request.body as dynamic;
+    }
     if (_body == null) {
       if (shouldValidateMultipart && request.contentType.isMultipart) {
         throw StateError(
@@ -146,15 +160,6 @@ class RequestContext<TBody> extends BaseContext {
       }
     }
     return _body as TBody;
-  }
-
-  /// Converts the internal raw body into the strongly-typed [TBody].
-  /// This should be called by the framework after Pipes have successfully executed.
-  void transformBody() {
-    if (_body != null && _body is! TBody) {
-      _body = _converter?.convert(_bodyType, _body);
-      request.body = _body;
-    }
   }
 
   /// Access the next part of a multipart request, validating and converting the entire body to [TBody].
@@ -168,6 +173,7 @@ class RequestContext<TBody> extends BaseContext {
     final converted = _converter?.convert(_bodyType, formData) as T;
     _body = converted;
     request.body = converted;
+    _bodyConverted = true;
     return converted;
   }
 
@@ -175,6 +181,28 @@ class RequestContext<TBody> extends BaseContext {
   set body(Object? value) {
     _body = _converter?.convert(_bodyType, value);
     request.body = _body;
+    _bodyConverted = true;
+  }
+
+  /// Replaces the body value without forcing conversion to [TBody].
+  void replaceRawBody(Object? value) {
+    _body = value;
+    request.body = value;
+    _bodyConverted = false;
+  }
+
+  /// Converts the current raw body to the declared [TBody] type.
+  void convertBodyToDeclaredType() {
+    if (_bodyConverted) {
+      return;
+    }
+    if (shouldValidateMultipart && request.contentType.isMultipart) {
+      return;
+    }
+    final converted = _converter?.convert(_bodyType, request.body) as TBody;
+    _body = converted;
+    request.body = converted;
+    _bodyConverted = true;
   }
 
   /// Casts the current body to a different type safely, operating on the raw [_body].

--- a/packages/serinus/lib/src/contexts/request_context.dart
+++ b/packages/serinus/lib/src/contexts/request_context.dart
@@ -31,12 +31,13 @@ class RequestContext<TBody> extends BaseContext {
        _bodyType = explicitType ?? _typeOf<TBody>(),
        _body = body,
        _bodyConverted = true,
+       _lastSeenRawBody = _staleBodySentinel,
        shouldValidateMultipart = shouldValidateMultipart,
        super(providers, values, hooksServices) {
     if (_converter?.modelProvider == null) {
       _converter = _BodyConverter(modelProvider);
     }
-    this.body = _converter?.convert(_bodyType, body);
+    this.body = body;
   }
 
   RequestContext._(
@@ -48,6 +49,7 @@ class RequestContext<TBody> extends BaseContext {
     Map<ValueToken, Object?> values,
     Map<Type, Object> hooksServices,
     this._bodyConverted,
+    this._lastSeenRawBody,
     bool shouldValidateMultipart,
   ) : _body = body,
       shouldValidateMultipart = shouldValidateMultipart,
@@ -83,6 +85,7 @@ class RequestContext<TBody> extends BaseContext {
         values,
         hooksServices,
         false,
+        _staleBodySentinel,
         shouldValidateMultipart,
       );
     }
@@ -96,6 +99,11 @@ class RequestContext<TBody> extends BaseContext {
       raw = null;
     }
     request.body = raw;
+    final targetTypeName = targetType.toString();
+    final isDynamicLikeTarget =
+        targetTypeName == 'dynamic' ||
+        targetTypeName == 'Object' ||
+        targetTypeName == 'Object?';
     return RequestContext._(
       request,
       targetType,
@@ -104,7 +112,8 @@ class RequestContext<TBody> extends BaseContext {
       providers,
       values,
       hooksServices,
-      explicitType == null,
+      isDynamicLikeTarget,
+      isDynamicLikeTarget ? request.body : _staleBodySentinel,
       shouldValidateMultipart,
     );
   }
@@ -117,9 +126,18 @@ class RequestContext<TBody> extends BaseContext {
   /// Indicates whether multipart requests should be validated before accessing the body.
   final bool shouldValidateMultipart;
 
+  /// Unique sentinel that signals the converted body is stale and
+  /// needs reconversion. Using a private object guarantees it can
+  /// never collide with a real body value.
+  static final Object _staleBodySentinel = Object();
+
   Object? _body;
 
   bool _bodyConverted;
+
+  /// The last raw body reference that was converted. Compared via
+  /// [identical] to detect external mutations to [request.body].
+  Object? _lastSeenRawBody;
 
   /// Returns the request path.
   String get path => request.path;
@@ -152,6 +170,9 @@ class RequestContext<TBody> extends BaseContext {
     if (!_bodyConverted) {
       return request.body as dynamic;
     }
+    if (!identical(_lastSeenRawBody, request.body)) {
+      _applyConversion(request.body);
+    }
     if (_body == null) {
       if (shouldValidateMultipart && request.contentType.isMultipart) {
         throw StateError(
@@ -170,18 +191,12 @@ class RequestContext<TBody> extends BaseContext {
       return bodyAs<T>();
     }
     final formData = await request.parseBody(rawBody: false, onPart: onPart);
-    final converted = _converter?.convert(_bodyType, formData) as T;
-    _body = converted;
-    request.body = converted;
-    _bodyConverted = true;
-    return converted;
+    return _applyConversion(formData) as T;
   }
 
   /// Replaces the body value ensuring it conforms to [TBody].
   set body(Object? value) {
-    _body = _converter?.convert(_bodyType, value);
-    request.body = _body;
-    _bodyConverted = true;
+    _applyConversion(value);
   }
 
   /// Replaces the body value without forcing conversion to [TBody].
@@ -189,6 +204,7 @@ class RequestContext<TBody> extends BaseContext {
     _body = value;
     request.body = value;
     _bodyConverted = false;
+    _lastSeenRawBody = _staleBodySentinel;
   }
 
   /// Converts the current raw body to the declared [TBody] type.
@@ -199,10 +215,19 @@ class RequestContext<TBody> extends BaseContext {
     if (shouldValidateMultipart && request.contentType.isMultipart) {
       return;
     }
-    final converted = _converter?.convert(_bodyType, request.body) as TBody;
+    _applyConversion(request.body);
+  }
+
+  /// Centralised conversion helper. Converts [rawValue] to [_bodyType],
+  /// stores the result locally, mirrors it on [request.body], and records
+  /// the reference so that future [identical] checks pass.
+  Object? _applyConversion(Object? rawValue) {
+    final converted = _converter?.convert(_bodyType, rawValue);
     _body = converted;
     request.body = converted;
     _bodyConverted = true;
+    _lastSeenRawBody = converted;
+    return converted;
   }
 
   /// Casts the current body to a different type safely, operating on the raw [_body].

--- a/packages/serinus/lib/src/core/pipe.dart
+++ b/packages/serinus/lib/src/core/pipe.dart
@@ -32,8 +32,8 @@ class BodySchemaValidationPipe extends Pipe {
     }
     try {
       final reqContext = context.switchToHttp();
-      final result = schema.parse(reqContext.body);
-      reqContext.body = result.value;
+      final result = schema.parse(argsHost.body);
+      reqContext.replaceRawBody(result.value);
     } on ValidationError catch (e) {
       throw onError?.call(e.key, e) ?? BadRequestException('$e');
     }
@@ -191,15 +191,39 @@ class ParseBoolPipe extends Pipe {
       return;
     }
     if (bindingType == PipeBindingType.params) {
-      final boolValue =
-          argsHost.params[key]?.toString().toLowerCase() == 'true';
+      final boolValue = _parseBool(argsHost.params[key]);
+      if (boolValue == null) {
+        throw onError?.call(key) ??
+            BadRequestException('Invalid parameter: $key');
+      }
       argsHost.params[key] = boolValue;
     }
     if (bindingType == PipeBindingType.query) {
-      final boolValue = argsHost.query[key]?.toString().toLowerCase() == 'true';
+      final boolValue = _parseBool(argsHost.query[key]);
+      if (boolValue == null) {
+        throw onError?.call(key) ??
+            BadRequestException('Invalid query parameter: $key');
+      }
       argsHost.query[key] = boolValue;
     }
   }
+}
+
+bool? _parseBool(Object? value) {
+  if (value is bool) {
+    return value;
+  }
+  if (value == null) {
+    return null;
+  }
+  final normalized = value.toString().trim().toLowerCase();
+  if (normalized == 'true') {
+    return true;
+  }
+  if (normalized == 'false') {
+    return false;
+  }
+  return null;
 }
 
 /// Represents a default value pipe.

--- a/packages/serinus/lib/src/http/request.dart
+++ b/packages/serinus/lib/src/http/request.dart
@@ -125,7 +125,12 @@ class Request {
   }
 
   /// The body of the request.
-  Object? body;
+  Object? get body => _body;
+  set body(Object? value) {
+    _body = value;
+  }
+
+  Object? _body;
 
   bool _bodyParsed = false;
 

--- a/packages/serinus/lib/src/routes/route_execution_context.dart
+++ b/packages/serinus/lib/src/routes/route_execution_context.dart
@@ -116,6 +116,7 @@ class RouteExecutionContext {
           await context.pipes[i].transform(executionContext);
         }
       }
+      requestContext.convertBodyToDeclaredType();
       final middlewares =
           context.compiledMiddlewares; // Instant O(1) cache read
       final activeMiddlewares = <Middleware>[];

--- a/packages/serinus/lib/src/routes/routes_resolver.dart
+++ b/packages/serinus/lib/src/routes/routes_resolver.dart
@@ -131,14 +131,27 @@ class RoutesResolver {
       _container.config.globalHooks.services,
       HttpArgumentsHost(wrappedRequest),
     );
-    final requestContext = await RequestContext.create<dynamic>(
-      request: wrappedRequest,
-      providers: providers,
-      values: values,
-      hooksServices: _container.config.globalHooks.services,
-      modelProvider: _container.config.modelProvider,
-      rawBody: _container.applicationRef.rawBody,
-    );
+    RequestContext requestContext;
+    try {
+      requestContext = await RequestContext.create<dynamic>(
+        request: wrappedRequest,
+        providers: providers,
+        values: values,
+        hooksServices: _container.config.globalHooks.services,
+        modelProvider: _container.config.modelProvider,
+        rawBody: _container.applicationRef.rawBody,
+      );
+    } on SerinusException {
+      requestContext = RequestContext.withBody(
+        wrappedRequest,
+        wrappedRequest.body,
+        providers,
+        values,
+        _container.config.globalHooks.services,
+        modelProvider: _container.config.modelProvider,
+        explicitType: dynamic,
+      );
+    }
     executionContext.attachHttpContext(requestContext);
     executionContext.response.statusCode = exception.statusCode;
     if (request.events.hasListener) {

--- a/packages/serinus/test/core/pipe_test.dart
+++ b/packages/serinus/test/core/pipe_test.dart
@@ -1,0 +1,107 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:mocktail/mocktail.dart';
+import 'package:serinus/serinus.dart';
+import 'package:test/test.dart';
+
+class _MockIncomingMessage extends Mock implements IncomingMessage {}
+
+class _MockHttpHeaders extends Mock implements HttpHeaders {}
+
+Request _buildRequest({
+  Map<String, String> queryParameters = const {},
+  Map<String, dynamic> params = const {},
+}) {
+  final incoming = _MockIncomingMessage();
+  when(() => incoming.queryParameters).thenReturn(queryParameters);
+  when(() => incoming.headers).thenReturn(SerinusHeaders(_MockHttpHeaders()));
+  when(() => incoming.contentType).thenReturn(ContentType.text);
+  when(() => incoming.method).thenReturn('GET');
+  when(() => incoming.path).thenReturn('/test');
+  when(() => incoming.uri).thenReturn(Uri.parse('http://localhost/test'));
+  when(() => incoming.id).thenReturn('req-pipe-1');
+  when(() => incoming.host).thenReturn('localhost');
+  when(() => incoming.hostname).thenReturn('localhost');
+  when(() => incoming.port).thenReturn(3000);
+  when(() => incoming.cookies).thenReturn(const []);
+  when(() => incoming.segments).thenReturn(const ['test']);
+  when(() => incoming.clientInfo).thenReturn(null);
+  when(() => incoming.contentLength).thenReturn(0);
+  when(() => incoming.isWebSocket).thenReturn(false);
+  when(() => incoming.webSocketKey).thenReturn('');
+  when(() => incoming.body()).thenReturn('');
+  when(() => incoming.json()).thenReturn(null);
+  when(() => incoming.bytes()).thenAnswer((_) async => Uint8List(0));
+  when(() => incoming.stream()).thenAnswer((_) => const Stream.empty());
+  when(() => incoming.formData()).thenAnswer(
+    (_) async => FormData(
+      contentType: ContentType('application', 'x-www-form-urlencoded'),
+    ),
+  );
+  return Request(incoming, params);
+}
+
+ExecutionContext<HttpArgumentsHost> _buildContext(Request request) {
+  return ExecutionContext(
+    HostType.http,
+    <Type, Provider>{},
+    <ValueToken, Object?>{},
+    <Type, Object>{},
+    HttpArgumentsHost(request),
+  );
+}
+
+void main() {
+  group('$ParseBoolPipe', () {
+    test('parses true and false query values', () async {
+      final request = _buildRequest(queryParameters: {'active': 'false'});
+      final context = _buildContext(request);
+
+      await ParseBoolPipe(
+        'active',
+        bindingType: PipeBindingType.query,
+      ).transform(context);
+
+      expect(request.query['active'], isFalse);
+    });
+
+    test('parses true and false params values', () async {
+      final request = _buildRequest(params: {'enabled': 'true'});
+      final context = _buildContext(request);
+
+      await ParseBoolPipe(
+        'enabled',
+        bindingType: PipeBindingType.params,
+      ).transform(context);
+
+      expect(request.params['enabled'], isTrue);
+    });
+
+    test('throws on invalid query values', () async {
+      final request = _buildRequest(queryParameters: {'active': 'yes'});
+      final context = _buildContext(request);
+
+      expect(
+        () => ParseBoolPipe(
+          'active',
+          bindingType: PipeBindingType.query,
+        ).transform(context),
+        throwsA(isA<BadRequestException>()),
+      );
+    });
+
+    test('throws on invalid params values', () async {
+      final request = _buildRequest(params: {'enabled': 'nope'});
+      final context = _buildContext(request);
+
+      expect(
+        () => ParseBoolPipe(
+          'enabled',
+          bindingType: PipeBindingType.params,
+        ).transform(context),
+        throwsA(isA<BadRequestException>()),
+      );
+    });
+  });
+}

--- a/packages/serinus/test/http/typed_body_test.dart
+++ b/packages/serinus/test/http/typed_body_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -29,6 +30,19 @@ class TestObject {
   }
 }
 
+class _TestModelProvider extends ModelProvider {
+  @override
+  Map<String, Function> get fromJsonModels => {
+    'TestObject': (json) => TestObject.fromJson(json as Map<String, dynamic>),
+  };
+
+  @override
+  // TODO: implement toJsonModels
+  Map<String, Function> get toJsonModels => {
+    'TestObject': (model) => {'name': (model as TestObject).name},
+  };
+}
+
 class MockHttpHeaders extends Mock implements HttpHeaders {}
 
 Request _buildRequest({ContentType? contentType}) {
@@ -53,6 +67,42 @@ Request _buildRequest({ContentType? contentType}) {
   when(() => incoming.body()).thenReturn('');
   when(() => incoming.json()).thenReturn(null);
   when(() => incoming.bytes()).thenAnswer((_) async => Uint8List(0));
+  when(() => incoming.stream()).thenAnswer((_) => const Stream.empty());
+  when(() => incoming.formData()).thenAnswer(
+    (_) async => FormData(
+      contentType: ContentType('application', 'x-www-form-urlencoded'),
+    ),
+  );
+  return Request(incoming);
+}
+
+Request _buildRequestWithBody({
+  required Object? jsonBody,
+  ContentType? contentType,
+}) {
+  final incoming = _MockIncomingMessage();
+  final effectiveContentType = contentType ?? jsonContentType;
+  when(() => incoming.queryParameters).thenReturn({});
+  when(() => incoming.headers).thenReturn(SerinusHeaders(MockHttpHeaders()));
+  when(() => incoming.contentType).thenReturn(effectiveContentType);
+  when(() => incoming.method).thenReturn('POST');
+  when(() => incoming.path).thenReturn('/');
+  when(() => incoming.uri).thenReturn(Uri.parse('http://localhost'));
+  when(() => incoming.id).thenReturn('req-2');
+  when(() => incoming.host).thenReturn('localhost');
+  when(() => incoming.hostname).thenReturn('localhost');
+  when(() => incoming.port).thenReturn(3000);
+  when(() => incoming.cookies).thenReturn(const []);
+  when(() => incoming.segments).thenReturn(const []);
+  when(() => incoming.clientInfo).thenReturn(null);
+  when(() => incoming.contentLength).thenReturn(1);
+  when(() => incoming.isWebSocket).thenReturn(false);
+  when(() => incoming.webSocketKey).thenReturn('');
+  when(() => incoming.body()).thenReturn(jsonEncode(jsonBody));
+  when(() => incoming.json()).thenReturn(jsonBody);
+  when(
+    () => incoming.bytes(),
+  ).thenAnswer((_) async => Uint8List.fromList(utf8.encode('x')));
   when(() => incoming.stream()).thenAnswer((_) => const Stream.empty());
   when(() => incoming.formData()).thenAnswer(
     (_) async => FormData(
@@ -168,6 +218,63 @@ void main() {
 
       expect(context.body, isA<TestObject>());
       expect((context.body as TestObject).name, equals('bird'));
+    });
+
+    test('defers typed conversion until explicitly requested', () async {
+      final request = _buildRequestWithBody(jsonBody: {'name': 'bird'});
+      final modelProvider = _MockModelProvider();
+      final context = await RequestContext.create<TestObject>(
+        request: request,
+        providers: <Type, Provider>{},
+        values: <ValueToken, Object?>{},
+        hooksServices: <Type, Object>{},
+        modelProvider: modelProvider,
+        rawBody: false,
+        explicitType: TestObject,
+      );
+
+      expect(context.request.body, isA<Map<String, dynamic>>());
+      expect((context.request.body as Map<String, dynamic>)['name'], 'bird');
+
+      context.convertBodyToDeclaredType();
+
+      expect(context.body, isA<TestObject>());
+      expect(context.body.name, equals('bird'));
+      expect(context.request.body, isA<TestObject>());
+    });
+
+    test('switchToHttp exposes raw body before conversion', () async {
+      final request = _buildRequestWithBody(jsonBody: {'name': 'bird'});
+      final context = await RequestContext.create<TestObject>(
+        request: request,
+        providers: <Type, Provider>{},
+        values: <ValueToken, Object?>{},
+        hooksServices: <Type, Object>{},
+        modelProvider: _TestModelProvider(),
+        rawBody: false,
+        explicitType: TestObject,
+      );
+
+      final executionContext = ExecutionContext(
+        HostType.http,
+        <Type, Provider>{},
+        <ValueToken, Object?>{},
+        <Type, Object>{},
+        HttpArgumentsHost(request),
+      );
+      executionContext.attachHttpContext(context);
+
+      final httpContext = executionContext.switchToHttp();
+
+      expect(httpContext.body, isA<Map<String, dynamic>>());
+      expect(
+        (httpContext.body as Map<String, dynamic>)['name'],
+        equals('bird'),
+      );
+
+      context.convertBodyToDeclaredType();
+
+      expect(context.body, isA<TestObject>());
     });
   });
 }

--- a/packages/serinus/test/http/typed_body_test.dart
+++ b/packages/serinus/test/http/typed_body_test.dart
@@ -243,6 +243,33 @@ void main() {
       expect(context.request.body, isA<TestObject>());
     });
 
+    test(
+      'defers typed conversion for create<TBody> without explicitType',
+      () async {
+        final request = _buildRequestWithBody(jsonBody: {'name': 'bird'});
+        final context = await RequestContext.create<TestObject>(
+          request: request,
+          providers: <Type, Provider>{},
+          values: <ValueToken, Object?>{},
+          hooksServices: <Type, Object>{},
+          modelProvider: _TestModelProvider(),
+          rawBody: false,
+        );
+
+        expect(context.rawBody, isA<Map<String, dynamic>>());
+        expect(
+          (context.rawBody as Map<String, dynamic>)['name'],
+          equals('bird'),
+        );
+
+        context.convertBodyToDeclaredType();
+
+        expect(context.body, isA<TestObject>());
+        expect(context.body.name, equals('bird'));
+        expect(context.request.body, isA<TestObject>());
+      },
+    );
+
     test('switchToHttp exposes raw body before conversion', () async {
       final request = _buildRequestWithBody(jsonBody: {'name': 'bird'});
       final context = await RequestContext.create<TestObject>(
@@ -276,5 +303,28 @@ void main() {
 
       expect(context.body, isA<TestObject>());
     });
+
+    test(
+      're-converts typed body when request.body is replaced later',
+      () async {
+        final request = _buildRequestWithBody(jsonBody: {'name': 'bird'});
+        final context = await RequestContext.create<TestObject>(
+          request: request,
+          providers: <Type, Provider>{},
+          values: <ValueToken, Object?>{},
+          hooksServices: <Type, Object>{},
+          modelProvider: _TestModelProvider(),
+          rawBody: false,
+        );
+
+        context.convertBodyToDeclaredType();
+        expect(context.body.name, equals('bird'));
+
+        request.body = {'name': 'hawk'};
+
+        expect(context.body, isA<TestObject>());
+        expect(context.body.name, equals('hawk'));
+      },
+    );
   });
 }

--- a/packages/serinus/test/http/websocket_test.dart
+++ b/packages/serinus/test/http/websocket_test.dart
@@ -90,17 +90,21 @@ void main() {
         );
         WebSocket? ws;
         WebSocket? unexpectedWs;
+        var invalidPathRejected = false;
         await app.serve();
         try {
           try {
             unexpectedWs = await WebSocket.connect(
               'ws://localhost:3001/',
             ).timeout(const Duration(seconds: 5));
-            await unexpectedWs.close().timeout(const Duration(seconds: 2));
-            unexpectedWs = null;
+            fail(
+              'Expected invalid websocket path ws://localhost:3001/ to be rejected, but connection succeeded.',
+            );
           } on WebSocketException {
-            // Acceptable: invalid path rejected.
+            invalidPathRejected = true;
           }
+
+          expect(invalidPathRejected, isTrue);
 
           ws = await WebSocket.connect(
             'ws://localhost:3001/ws',

--- a/packages/serinus/test/http/websocket_test.dart
+++ b/packages/serinus/test/http/websocket_test.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:async/async.dart';
 import 'package:serinus/serinus.dart';
 import 'package:test/test.dart';
 
@@ -89,21 +88,40 @@ void main() {
           logLevels: {LogLevel.none},
           port: 3001,
         );
+        WebSocket? ws;
+        WebSocket? unexpectedWs;
         await app.serve();
         try {
-          await WebSocket.connect('ws://localhost:3001/');
-        } catch (e) {
-          expect(e, isA<WebSocketException>());
+          try {
+            unexpectedWs = await WebSocket.connect(
+              'ws://localhost:3001/',
+            ).timeout(const Duration(seconds: 5));
+            await unexpectedWs.close().timeout(const Duration(seconds: 2));
+            unexpectedWs = null;
+          } on WebSocketException {
+            // Acceptable: invalid path rejected.
+          }
+
+          ws = await WebSocket.connect(
+            'ws://localhost:3001/ws',
+          ).timeout(const Duration(seconds: 5));
+          ws.add('Hello from client');
+          final message = await ws.first.timeout(const Duration(seconds: 5));
+          expect(message, 'Hello from client');
+        } finally {
+          if (unexpectedWs != null) {
+            await unexpectedWs.close().timeout(const Duration(seconds: 2));
+          }
+          if (ws != null) {
+            await ws.close().timeout(const Duration(seconds: 2));
+          }
+          await app.close().timeout(const Duration(seconds: 5));
         }
-        final ws = await WebSocket.connect('ws://localhost:3001/ws');
-        ws.add('Hello from client');
-        final message = await ws.firstOrNull;
-        expect(message, 'Hello from client');
       },
     );
 
     test(
-      'when a module import the WsModule and use a WebSocketGateway and the path param is not null then the gateway should only accept connections on the specified path',
+      'when a module import the WsModule and use a WebSocketGatewayMixins then it should trigger connect callback and echo messages',
       () async {
         final gateway = WsGatewayMixins(path: '/ws');
         final app = await serinus.createApplication(


### PR DESCRIPTION
# Description

The pipes now access the body not yet converted deferring the conversion after all the pipes are executed

## Type of change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a request pipeline component that can inspect and modify incoming requests.
  * Root endpoint now accepts POST and echoes the submitted body.

* **Bug Fixes**
  * Stricter parsing and validation for boolean query/param values with clearer errors.
  * More resilient request-context creation during error handling.
  * WebSocket requests to unknown routes now return 404 earlier to avoid unnecessary upgrades.

* **Improvements**
  * Deferred request-body conversion with raw payload exposed before conversion.
  * Body conversion now runs after request pipes for more consistent validation.

* **Tests**
  * New tests for typed-body conversion, boolean parsing, and websocket flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->